### PR TITLE
refactor: simplify client reference registration transform

### DIFF
--- a/vue-server/package.json
+++ b/vue-server/package.json
@@ -29,6 +29,7 @@
 		"@hiogawa/utils": "1.6.4-pre.2",
 		"@hiogawa/vite-plugin-ssr-middleware": "^0.0.3",
 		"@playwright/test": "^1.44.0",
+		"@types/estree": "^1.0.5",
 		"@types/node": "^20.12.10",
 		"@vitejs/plugin-vue": "^5.0.4",
 		"esbuild": "^0.21.0",

--- a/vue-server/pnpm-lock.yaml
+++ b/vue-server/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
       '@playwright/test':
         specifier: ^1.44.0
         version: 1.44.0
+      '@types/estree':
+        specifier: ^1.0.5
+        version: 1.0.5
       '@types/node':
         specifier: ^20.12.10
         version: 20.12.10

--- a/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
+++ b/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
@@ -10,8 +10,8 @@ export const Arrow = () => {};
 
 export default "hi";
 
-// TODO
 export function Fn() {}
+export async function AsyncFn() {}
 export class Cls {}
 `;
 
@@ -23,9 +23,9 @@ export class Cls {}
 
 			export default /* @__PURE__ */ $$register(("hi"), "<id>#default");
 
-			// TODO
-			export /* @__PURE__ */ $$register((function Fn() {}), "<id>#Fn")
-			export /* @__PURE__ */ $$register((class Cls {}), "<id>#Cls")
+			export const Fn = /* @__PURE__ */ $$register((function Fn() {}), "<id>#Fn")
+			export const AsyncFn = /* @__PURE__ */ $$register((async function AsyncFn() {}), "<id>#AsyncFn")
+			export const Cls = /* @__PURE__ */ $$register((class Cls {}), "<id>#Cls")
 			"
 		`);
 	});
@@ -49,6 +49,7 @@ export class Cls {}
 	});
 
 	test("unsupported", async () => {
+    // TODO
 		const input = `\
       const x = 0;
       export { x }

--- a/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
+++ b/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
-import { parseExports, transformClientReference } from "./plugin-utils";
+import { transformClientReference } from "./plugin-utils";
 
-describe(parseExports, () => {
+describe(transformClientReference, () => {
 	test("basic", async () => {
 		const input = `\
 import { defineComponent, h } from "vue";
@@ -28,5 +28,14 @@ export class Cls {}
 			export /* @__PURE__ */ $$register((class Cls {}), "<id>#Cls")
 			"
 		`);
+	});
+
+	test("default", async () => {
+		const input = `export default "hi"`;
+
+		const output = await transformClientReference(input, "<id>");
+		expect(output.toString()).toMatchInlineSnapshot(
+			`"import { registerClientReference as $$register } from "/src/serialize";export default /* @__PURE__ */ $$register(("hi"), "<id>#default")"`,
+		);
 	});
 });

--- a/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
+++ b/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
@@ -6,12 +6,12 @@ describe(transformClientReference, () => {
 		const input = `\
 import { defineComponent, h } from "vue";
 
-export const Arrow = () => "hi";
+export const Arrow = () => {};
 
 export default "hi";
 
 // TODO
-export function Fn() { return "hi" }
+export function Fn() {}
 export class Cls {}
 `;
 
@@ -19,23 +19,32 @@ export class Cls {}
 		expect(output.toString()).toMatchInlineSnapshot(`
 			"import { registerClientReference as $$register } from "/src/serialize";import { defineComponent, h } from "vue";
 
-			export const Arrow = /* @__PURE__ */ $$register((() => "hi"), "<id>#Arrow");
+			export const Arrow = /* @__PURE__ */ $$register((() => {}), "<id>#Arrow");
 
 			export default /* @__PURE__ */ $$register(("hi"), "<id>#default");
 
 			// TODO
-			export /* @__PURE__ */ $$register((function Fn() { return "hi" }), "<id>#Fn")
+			export /* @__PURE__ */ $$register((function Fn() {}), "<id>#Fn")
 			export /* @__PURE__ */ $$register((class Cls {}), "<id>#Cls")
 			"
 		`);
 	});
 
-	test("default", async () => {
-		const input = `export default "hi"`;
+	test("default function", async () => {
+		const input = `export default function Fn() {}`;
 
 		const output = await transformClientReference(input, "<id>");
 		expect(output.toString()).toMatchInlineSnapshot(
-			`"import { registerClientReference as $$register } from "/src/serialize";export default /* @__PURE__ */ $$register(("hi"), "<id>#default")"`,
+			`"import { registerClientReference as $$register } from "/src/serialize";export default /* @__PURE__ */ $$register((function Fn() {}), "<id>#default")"`,
+		);
+	});
+
+	test("default class", async () => {
+		const input = `export default class Cls {}`;
+
+		const output = await transformClientReference(input, "<id>");
+		expect(output.toString()).toMatchInlineSnapshot(
+			`"import { registerClientReference as $$register } from "/src/serialize";export default /* @__PURE__ */ $$register((class Cls {}), "<id>#default")"`,
 		);
 	});
 });

--- a/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
+++ b/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { parseExports, transformClientReference } from "./plugin-utils";
+
+describe(parseExports, () => {
+	test("basic", async () => {
+		const input = `\
+import { defineComponent, h } from "vue";
+
+export const Arrow = () => "hi";
+
+export default "hi";
+
+// TODO
+export function Fn() { return "hi" }
+export class Cls {}
+`;
+
+		const output = await transformClientReference(input, "<id>");
+		expect(output.toString()).toMatchInlineSnapshot(`
+			"import { registerClientReference as $$register } from "/src/serialize";import { defineComponent, h } from "vue";
+
+			export const Arrow = /* @__PURE__ */ $$register((() => "hi"), "<id>#Arrow");
+
+			export default /* @__PURE__ */ $$register(("hi"), "<id>#default");
+
+			// TODO
+			export /* @__PURE__ */ $$register((function Fn() { return "hi" }), "<id>#Fn")
+			export /* @__PURE__ */ $$register((class Cls {}), "<id>#Cls")
+			"
+		`);
+	});
+});

--- a/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
+++ b/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
@@ -49,7 +49,7 @@ export class Cls {}
 	});
 
 	test("unsupported", async () => {
-    // TODO
+		// TODO
 		const input = `\
       const x = 0;
       export { x }

--- a/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
+++ b/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
@@ -47,4 +47,15 @@ export class Cls {}
 			`"import { registerClientReference as $$register } from "/src/serialize";export default /* @__PURE__ */ $$register((class Cls {}), "<id>#default")"`,
 		);
 	});
+
+	test("unsupported", async () => {
+		const input = `\
+      const x = 0;
+      export { x }
+    `;
+
+		expect(() =>
+			transformClientReference(input, "<id>"),
+		).rejects.toMatchInlineSnapshot(`[Error: unsupported]`);
+	});
 });

--- a/vue-server/src/demo/integrations/client-reference/plugin-utils.ts
+++ b/vue-server/src/demo/integrations/client-reference/plugin-utils.ts
@@ -1,0 +1,135 @@
+import { tinyassert } from "@hiogawa/utils";
+import type * as estree from "estree";
+import { type Plugin, parseAstAsync } from "vite";
+import { MagicString } from "vue/compiler-sfc";
+
+export async function transformClientReference(input: string, id: string) {
+	const { entries } = await parseExports(input);
+	const output = new MagicString(input);
+	output.prepend(
+		`import { registerClientReference as $$register } from "/src/serialize";`,
+	);
+	for (const entry of entries) {
+		output.prependRight(entry.node.start, "/* @__PURE__ */ $$register((");
+		output.prependRight(entry.node.end, `), "${id}#${entry.name}")`);
+	}
+	return output;
+}
+
+// extend types for rollup ast with node position
+declare module "estree" {
+	interface BaseNode {
+		start: number;
+		end: number;
+	}
+}
+
+export async function parseExports(input: string) {
+	const ast = await parseAstAsync(input);
+	const entries: { name: string; node: estree.BaseNode }[] = [];
+
+	for (const node of ast.body) {
+		// named exports
+		if (node.type === "ExportNamedDeclaration") {
+			if (node.declaration) {
+				if (
+					node.declaration.type === "FunctionDeclaration" ||
+					node.declaration.type === "ClassDeclaration"
+				) {
+					/**
+					 * export function foo() {}
+					 */
+					entries.push({
+						name: node.declaration.id.name,
+						node: node.declaration,
+					});
+				} else if (node.declaration.type === "VariableDeclaration") {
+					/**
+					 * export const foo = 1, bar = 2
+					 */
+					for (const decl of node.declaration.declarations) {
+						tinyassert(decl.id.type === "Identifier");
+						tinyassert(decl.init);
+						entries.push({
+							name: decl.id.name,
+							node: decl.init,
+						});
+					}
+				} else {
+					console.error(node);
+					throw new Error("unsupported");
+				}
+			}
+		}
+
+		/**
+		 * export default function foo() {}
+		 * export default class A {}
+		 * export default () => {}
+		 */
+		if (node.type === "ExportDefaultDeclaration") {
+			entries.push({
+				name: "default",
+				node: node.declaration,
+			});
+		}
+	}
+
+	return { entries };
+}
+
+export function createVirtualPlugin(name: string, load: Plugin["load"]) {
+	name = "virtual:" + name;
+	return {
+		name,
+		resolveId(source, _importer, _options) {
+			if (source === name || source.startsWith(`${name}?`)) {
+				return `\0${source}`;
+			}
+			return;
+		},
+		load(id, options) {
+			if (id === `\0${name}` || id.startsWith(`\0${name}?`)) {
+				return (load as any).apply(this, [id, options]);
+			}
+		},
+	} satisfies Plugin;
+}
+
+export function vitePluginSilenceDirectiveBuildWarning(): Plugin {
+	return {
+		name: vitePluginSilenceDirectiveBuildWarning.name,
+		enforce: "post",
+		config(config, _env) {
+			return {
+				build: {
+					rollupOptions: {
+						onwarn(warning, defaultHandler) {
+							// https://github.com/vitejs/vite/issues/15012#issuecomment-1948550039
+							if (
+								warning.code === "SOURCEMAP_ERROR" &&
+								warning.loc?.line === 1 &&
+								warning.loc.column === 0
+							) {
+								return;
+							}
+							// https://github.com/TanStack/query/pull/5161#issuecomment-1506683450
+							if (
+								(warning.code === "MODULE_LEVEL_DIRECTIVE" &&
+									warning.message.includes(`"use client"`)) ||
+								warning.message.includes(`"use server"`)
+							) {
+								return;
+							}
+							if (config.build?.rollupOptions?.onwarn) {
+								config.build.rollupOptions.onwarn(warning, defaultHandler);
+							} else {
+								defaultHandler(warning);
+							}
+						},
+					},
+				},
+			};
+		},
+	};
+}

--- a/vue-server/src/serialize.ts
+++ b/vue-server/src/serialize.ts
@@ -148,7 +148,7 @@ function deserializeNodeType(s: any) {
 }
 
 export function registerClientReference(v: any, __reference_id: string) {
-	Object.assign(v, { __reference_id });
+	return Object.assign(v, { __reference_id });
 }
 
 //

--- a/vue-server/vite.config.ts
+++ b/vue-server/vite.config.ts
@@ -18,6 +18,7 @@ import vitPluginInspect from "vite-plugin-inspect";
 import {
 	createVirtualPlugin,
 	transformClientReference,
+	transformEmptyExports,
 	vitePluginSilenceDirectiveBuildWarning,
 } from "./src/demo/integrations/client-reference/plugin-utils";
 
@@ -162,12 +163,11 @@ function clientReferencePlugin(): PluginOption {
 						(id.endsWith(".vue") && /__vite_useSSRContext/.test(code))
 					) {
 						clientBoundaryIds.add(id);
-						// TODO
-						// don't crawl further once client boundary is found,
-						// but still need to fake exports to not break build.
 						if (manager.buildType === "server-pre") {
+							// don't need to crawl further once client boundary is found,
+							// but still need to fake exports to not break build.
+							return { code: await transformEmptyExports(code), map: null };
 						}
-
 						const result = await transformClientReference(code, id);
 						return { code: result.toString(), map: result.generateMap() };
 					}


### PR DESCRIPTION
Previously, I've been transforming reference by:

```ts
export const Something = () => {};

// just append
import { register } from "...runtime..."
register(Something, "<file>#Something")
```

but it doesn't look it's so hard to do this instead:

```ts
// prepend
import { register } from "...runtime...";

// and wrap
export const Something = register(() => {}, "<file>#Something");
```