### PR TITLE
fix: fix wrap transform for default export with name

### DIFF
--- a/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
+++ b/vue-server/src/demo/integrations/client-reference/plugin-utils.test.ts
@@ -22,13 +22,15 @@ export class Cls {};
 			"import { registerClientReference as $$wrap } from "/src/serialize";
 
 			 const Arrow = () => {};
-			export default $$wrap(("hi"), "<file>#default");
+			const $$default = "hi";
 			 function Fn() {};
 			 async function AsyncFn() {};
 			 class Cls {};
 			;
 			const $$tmp_Arrow = $$wrap((Arrow), "<file>#Arrow");
 			export { $$tmp_Arrow as Arrow };
+			const $$tmp_$$default = $$wrap(($$default), "<file>#default");
+			export { $$tmp_$$default as default };
 			const $$tmp_Fn = $$wrap((Fn), "<file>#Fn");
 			export { $$tmp_Fn as Fn };
 			const $$tmp_AsyncFn = $$wrap((AsyncFn), "<file>#AsyncFn");
@@ -44,7 +46,22 @@ export class Cls {};
 		expect(await testTransform(input)).toMatchInlineSnapshot(
 			`
 			"import { registerClientReference as $$wrap } from "/src/serialize";
-			export default $$wrap((function Fn() {}), "<file>#default");
+			function Fn() {};
+			const $$tmp_Fn = $$wrap((Fn), "<file>#default");
+			export { $$tmp_Fn as default };
+			"
+		`,
+		);
+	});
+
+	test("default anonymous function", async () => {
+		const input = `export default function () {}`;
+		expect(await testTransform(input)).toMatchInlineSnapshot(
+			`
+			"import { registerClientReference as $$wrap } from "/src/serialize";
+			const $$default = function () {};
+			const $$tmp_$$default = $$wrap(($$default), "<file>#default");
+			export { $$tmp_$$default as default };
 			"
 		`,
 		);
@@ -55,7 +72,9 @@ export class Cls {};
 		expect(await testTransform(input)).toMatchInlineSnapshot(
 			`
 			"import { registerClientReference as $$wrap } from "/src/serialize";
-			export default $$wrap((class Cls {}), "<file>#default");
+			class Cls {};
+			const $$tmp_Cls = $$wrap((Cls), "<file>#default");
+			export { $$tmp_Cls as default };
 			"
 		`,
 		);

--- a/vue-server/src/demo/routes/_client.tsx
+++ b/vue-server/src/demo/routes/_client.tsx
@@ -106,3 +106,7 @@ export const Hydrated = defineComponent(() => {
 	});
 	return () => <span>{`[mounted: ${mounted.value}]`}</span>;
 });
+
+export default function ClientDefault() {
+	return <span>Client default export</span>;
+}

--- a/vue-server/src/demo/routes/page.tsx
+++ b/vue-server/src/demo/routes/page.tsx
@@ -1,5 +1,5 @@
 import { defineComponent } from "vue";
-import { ClientCounter, ClientNested } from "./_client";
+import ClientDefault, { ClientCounter, ClientNested } from "./_client";
 import ClientSfc from "./_client-sfc.vue";
 
 export default defineComponent(async () => {
@@ -10,6 +10,9 @@ export default defineComponent(async () => {
 			<h4>Client Component</h4>
 			<ClientCounter />
 			<ClientSfc />
+			<div style={{ margin: "0.5rem 0" }}>
+				<ClientDefault />
+			</div>
 			<h4>Nested Server/Client</h4>
 			<ServerNested>
 				{() => (


### PR DESCRIPTION
It looks like there is a difference between:

```ts
export default function f() {}

// can access
f();
```

```ts
export default $$wrap(function f() {})

// can not access
// f();
```

So, now we change to a following transform for default export:

```ts
function f() {}
const $$default = $$wrap(f)
export { $$deafult as f }

// can still access
f();
```
