### PR TITLE
feat(webpack-rsc): no ssr for debugging

### DIFF
--- a/webpack-rsc/src/entry-browser.tsx
+++ b/webpack-rsc/src/entry-browser.tsx
@@ -5,7 +5,8 @@ import type { FlightData } from "./entry-server";
 import { setupBrowserRouter } from "./lib/router/browser";
 
 async function main() {
-	if (window.location.search.includes("__nojs")) {
+	const url = new URL(window.location.href);
+	if (url.searchParams.has("__nojs")) {
 		return;
 	}
 
@@ -42,15 +43,20 @@ async function main() {
 		return <>{React.use(flight)}</>;
 	}
 
+	const root = (
+		<React.StrictMode>
+			<BrowserRoot />
+		</React.StrictMode>
+	);
+
 	// react dom browser (react node -> html)
-	React.startTransition(() => {
-		ReactDOMClient.hydrateRoot(
-			document,
-			<React.StrictMode>
-				<BrowserRoot />
-			</React.StrictMode>,
-		);
-	});
+	if (url.searchParams.has("__nossr")) {
+		ReactDOMClient.createRoot(document).render(root);
+	} else {
+		React.startTransition(() => {
+			ReactDOMClient.hydrateRoot(document, root);
+		});
+	}
 
 	if (__define.DEV) {
 		// @ts-expect-error
@@ -69,3 +75,9 @@ async function main() {
 }
 
 main();
+
+declare module "react-dom/client" {
+	interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_CREATE_ROOT_CONTAINERS {
+		Document: Document;
+	}
+}

--- a/webpack-rsc/src/entry-ssr.tsx
+++ b/webpack-rsc/src/entry-ssr.tsx
@@ -19,6 +19,31 @@ export async function handler(request: Request) {
 		});
 	}
 
+	if (url.searchParams.has("__nossr")) {
+		const ssrRoot = (
+			<html>
+				<head></head>
+				<body></body>
+			</html>
+		);
+		const bootstrapScripts = await getClientAssets();
+		const htmlStream = await ReactDOMServer.renderToReadableStream(ssrRoot, {
+			bootstrapScripts,
+		});
+
+		const htmlStreamFinal = htmlStream
+			.pipeThrough(new TextDecoderStream())
+			// send a copy of flight stream together with ssr
+			.pipeThrough(injectFlightStream(flightStream))
+			.pipeThrough(new TextEncoderStream());
+
+		return new Response(htmlStreamFinal, {
+			headers: {
+				"content-type": "text/html;charset=utf-8",
+			},
+		});
+	}
+
 	const [flightStream1, flightStream2] = flightStream.tee();
 
 	// react client (flight -> react node)


### PR DESCRIPTION
It would be convenient to be able to test browser without ssr, but code needs to be cleanup.
Also non hydration path will be needed for ssr error two-pass render.