### PR TITLE
feat(webpack-rsc): add root error boundary and two-pass ssr on error

### DIFF
--- a/webpack-rsc/e2e/basic.test.ts
+++ b/webpack-rsc/e2e/basic.test.ts
@@ -46,3 +46,24 @@ async function testNavigation(page: Page) {
 	await page.waitForURL("/");
 	await page.getByRole("heading", { name: "Webpack RSC" }).click();
 }
+
+test("error @js", async ({ page }) => {
+	await page.goto("/");
+	await waitForHydration(page);
+	await testError(page);
+	await page.getByRole("button", { name: "count is 0" }).click();
+	await page.getByRole("button", { name: "count is 1" }).click();
+});
+
+testNoJs("error @nojs", async ({ page }) => {
+	await page.goto("/");
+	await testError(page);
+});
+
+async function testError(page: Page) {
+	await page.getByRole("link", { name: "Error" }).click();
+	await page.waitForURL("/error");
+	await page.getByRole("heading", { name: "Something went wrong" }).click();
+	await page.getByRole("link", { name: "Home" }).click();
+	await page.waitForURL("/");
+}

--- a/webpack-rsc/src/lib/error-boundary.tsx
+++ b/webpack-rsc/src/lib/error-boundary.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface Props {
+	children?: React.ReactNode;
+	Fallback: React.FC;
+}
+
+interface State {
+	error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<Props, State> {
+	state = { error: null };
+
+	static getDerivedStateFromError(error: Error) {
+		return { error };
+	}
+
+	override render() {
+		const { error } = this.state;
+		const { children, Fallback } = this.props;
+		return error ? <Fallback /> : children;
+	}
+}

--- a/webpack-rsc/src/routes/global-error.tsx
+++ b/webpack-rsc/src/routes/global-error.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+export default function GlobalErrorPage() {
+	return (
+		<html>
+			<body>
+				<h3>Something went wrong</h3>
+				<div>
+					Back to <a href="/">Home</a>
+				</div>
+			</body>
+		</html>
+	);
+}

--- a/webpack-rsc/src/routes/layout.tsx
+++ b/webpack-rsc/src/routes/layout.tsx
@@ -23,6 +23,7 @@ export default function Layout(props: React.PropsWithChildren) {
 					Menu:
 					<a href="/">Home</a>
 					<a href="/stream">Stream</a>
+					<a href="/error">Error</a>
 				</div>
 				<div id="root" style={{ display: "flex", placeContent: "center" }}>
 					{props.children}


### PR DESCRIPTION
Don't plan to do full error digest thing, but this will allow handling invalid route.