### PR TITLE
feat(webpack-rsc): support server action

### DIFF
--- a/webpack-rsc/e2e/basic.test.ts
+++ b/webpack-rsc/e2e/basic.test.ts
@@ -67,3 +67,17 @@ async function testError(page: Page) {
 	await page.getByRole("link", { name: "Home" }).click();
 	await page.waitForURL("/");
 }
+
+test.only("action @js", async ({ page }) => {
+	await page.goto("/action");
+	await waitForHydration(page);
+	await page.getByText("Count is 0").click();
+	await page.getByRole("button", { name: "+" }).click();
+	await page.getByText("Count is 1").click();
+	await page.getByRole("button", { name: "-" }).click();
+	await page.getByText("Count is 0").click();
+});
+
+testNoJs("action @nojs", async ({ page }) => {
+	await page.goto("/action");
+});

--- a/webpack-rsc/e2e/basic.test.ts
+++ b/webpack-rsc/e2e/basic.test.ts
@@ -68,16 +68,22 @@ async function testError(page: Page) {
 	await page.waitForURL("/");
 }
 
-test.only("action @js", async ({ page }) => {
+test("action @js", async ({ page }) => {
 	await page.goto("/action");
 	await waitForHydration(page);
+	await using _ = await createReloadChecker(page);
+	await testAction(page);
+});
+
+testNoJs("action @nojs", async ({ page }) => {
+	await page.goto("/action");
+	await testAction(page);
+});
+
+async function testAction(page: Page) {
 	await page.getByText("Count is 0").click();
 	await page.getByRole("button", { name: "+" }).click();
 	await page.getByText("Count is 1").click();
 	await page.getByRole("button", { name: "-" }).click();
 	await page.getByText("Count is 0").click();
-});
-
-testNoJs("action @nojs", async ({ page }) => {
-	await page.goto("/action");
-});
+}

--- a/webpack-rsc/e2e/helper.ts
+++ b/webpack-rsc/e2e/helper.ts
@@ -5,7 +5,10 @@ export const testNoJs = test.extend({
 });
 
 export async function waitForHydration(page: Page) {
-	await expect(page.getByText("[hydrated: 1]")).toBeVisible();
+	await expect(page.locator(`meta[name="x-hydrated"]`)).toHaveAttribute(
+		"data-hydrated",
+		"true",
+	);
 }
 
 export async function createReloadChecker(page: Page) {

--- a/webpack-rsc/src/entry-browser.tsx
+++ b/webpack-rsc/src/entry-browser.tsx
@@ -8,7 +8,7 @@ import { setupBrowserRouter } from "./lib/router/browser";
 import GlobalErrorPage from "./routes/global-error";
 import type { CallServerCallback } from "./types/react-types";
 
-// TODO: this one still has issues
+// TODO: maybe we have to revert the previous PR
 // https://github.com/hi-ogawa/experiments/pull/33
 () => [
 	import("./routes/_client"),

--- a/webpack-rsc/src/entry-browser.tsx
+++ b/webpack-rsc/src/entry-browser.tsx
@@ -8,15 +8,6 @@ import { setupBrowserRouter } from "./lib/router/browser";
 import GlobalErrorPage from "./routes/global-error";
 import type { CallServerCallback } from "./types/react-types";
 
-// TODO: maybe we have to revert the previous PR
-// https://github.com/hi-ogawa/experiments/pull/33
-() => [
-	import("./routes/_client"),
-	import("./routes/_client2"),
-	import("./routes/stream/_client3"),
-	import("./routes/action/_client"),
-];
-
 async function main() {
 	const url = new URL(window.location.href);
 	if (url.searchParams.has("__nojs")) {

--- a/webpack-rsc/src/entry-browser.tsx
+++ b/webpack-rsc/src/entry-browser.tsx
@@ -73,8 +73,11 @@ async function main() {
 		// render client only on ssr error
 		ReactDOMClient.createRoot(document).render(browserRoot);
 	} else {
+		const formState = (await initialFlight).actionResult;
 		React.startTransition(() => {
-			ReactDOMClient.hydrateRoot(document, browserRoot);
+			ReactDOMClient.hydrateRoot(document, browserRoot, {
+				formState,
+			});
 		});
 	}
 
@@ -97,6 +100,10 @@ async function main() {
 main();
 
 declare module "react-dom/client" {
+	interface HydrationOptions {
+		formState?: unknown;
+	}
+
 	interface DO_NOT_USE_OR_YOU_WILL_BE_FIRED_EXPERIMENTAL_CREATE_ROOT_CONTAINERS {
 		Document: Document;
 	}

--- a/webpack-rsc/src/entry-browser.tsx
+++ b/webpack-rsc/src/entry-browser.tsx
@@ -8,6 +8,15 @@ import { setupBrowserRouter } from "./lib/router/browser";
 import GlobalErrorPage from "./routes/global-error";
 import type { CallServerCallback } from "./types/react-types";
 
+// TODO: this one still has issues
+// https://github.com/hi-ogawa/experiments/pull/33
+() => [
+	import("./routes/_client"),
+	import("./routes/_client2"),
+	import("./routes/stream/_client3"),
+	import("./routes/action/_client"),
+];
+
 async function main() {
 	const url = new URL(window.location.href);
 	if (url.searchParams.has("__nojs")) {

--- a/webpack-rsc/src/entry-server.tsx
+++ b/webpack-rsc/src/entry-server.tsx
@@ -2,17 +2,26 @@ import { tinyassert } from "@hiogawa/utils";
 import React from "react";
 import ReactServer from "react-server-dom-webpack/server.edge";
 import { getClientManifest } from "./lib/client-manifest";
+import { type ActionResult, actionHandler } from "./lib/server-action/server";
 import Layout from "./routes/layout";
 
-export type FlightData = React.ReactNode;
+export type FlightData = {
+	node: React.ReactNode;
+	actionResult?: ActionResult;
+};
 
 export async function handler(request: Request) {
+	let actionResult: ActionResult | undefined;
+	if (request.method === "POST") {
+		actionResult = await actionHandler(request);
+	}
+
 	const { browserManifest } = await getClientManifest();
 
 	// react server (react node -> flight)
 	const node = <Router request={request} />;
 	const flightStream = ReactServer.renderToReadableStream<FlightData>(
-		node,
+		{ node, actionResult },
 		browserManifest,
 	);
 	return flightStream;

--- a/webpack-rsc/src/entry-server.tsx
+++ b/webpack-rsc/src/entry-server.tsx
@@ -10,7 +10,12 @@ export type FlightData = {
 	actionResult?: ActionResult;
 };
 
-export async function handler(request: Request) {
+export type ServerResult = {
+	flightStream: ReadableStream<Uint8Array>;
+	actionResult?: ActionResult;
+};
+
+export async function handler(request: Request): Promise<ServerResult> {
 	let actionResult: ActionResult | undefined;
 	if (request.method === "POST") {
 		actionResult = await actionHandler(request);
@@ -24,7 +29,7 @@ export async function handler(request: Request) {
 		{ node, actionResult },
 		browserManifest,
 	);
-	return flightStream;
+	return { flightStream, actionResult };
 }
 
 // fs routes

--- a/webpack-rsc/src/entry-ssr.tsx
+++ b/webpack-rsc/src/entry-ssr.tsx
@@ -11,7 +11,8 @@ export async function handler(request: Request) {
 	const url = new URL(request.url);
 
 	// react server (react node -> flight)
-	const flightStream = await entryReactServer.handler(request);
+	const { flightStream, actionResult } =
+		await entryReactServer.handler(request);
 	if (url.searchParams.has("__f")) {
 		return new Response(flightStream, {
 			headers: {
@@ -37,6 +38,7 @@ export async function handler(request: Request) {
 	try {
 		htmlStream = await ReactDOMServer.renderToReadableStream(ssrRoot, {
 			bootstrapScripts,
+			formState: actionResult,
 		});
 	} catch (e) {
 		// two-pass render for ssr error
@@ -64,4 +66,10 @@ export async function handler(request: Request) {
 			"content-type": "text/html;charset=utf-8",
 		},
 	});
+}
+
+declare module "react-dom/server" {
+	interface RenderToReadableStreamOptions {
+		formState?: unknown;
+	}
 }

--- a/webpack-rsc/src/entry-ssr.tsx
+++ b/webpack-rsc/src/entry-ssr.tsx
@@ -24,10 +24,11 @@ export async function handler(request: Request) {
 
 	// react client (flight -> react node)
 	const { ssrManifest } = await getClientManifest();
-	const ssrRoot = await ReactClient.createFromReadableStream<FlightData>(
+	const flightData = await ReactClient.createFromReadableStream<FlightData>(
 		flightStream1,
 		{ ssrManifest },
 	);
+	const ssrRoot = flightData.node;
 
 	// react dom ssr (react node -> html)
 	let status = 200;

--- a/webpack-rsc/src/lib/global.ts
+++ b/webpack-rsc/src/lib/global.ts
@@ -1,0 +1,5 @@
+import type { CallServerCallback } from "../types/react-types";
+
+export const $__global: {
+	__f_call_server: CallServerCallback;
+} = globalThis as any;

--- a/webpack-rsc/src/lib/server-action/browser.tsx
+++ b/webpack-rsc/src/lib/server-action/browser.tsx
@@ -1,0 +1,8 @@
+import ReactClient from "react-server-dom-webpack/client.browser";
+import { $__global } from "../global";
+
+export function createServerReference(id: string, name: string) {
+	return ReactClient.createServerReference(id + "#" + name, (...args) =>
+		$__global.__f_call_server(...args),
+	);
+}

--- a/webpack-rsc/src/lib/server-action/server.tsx
+++ b/webpack-rsc/src/lib/server-action/server.tsx
@@ -20,8 +20,6 @@ export async function actionHandler(request: Request): Promise<ActionResult> {
 		const entry = serverManifest[$$id];
 		// @ts-expect-error
 		const mod = __webpack_require__(entry.id);
-		// TODO: export tree shaken...
-		console.log({ $$id, entry, mod });
 		boundAction = () => mod[entry.name](...args);
 	} else {
 		// progressive enhancement

--- a/webpack-rsc/src/lib/server-action/server.tsx
+++ b/webpack-rsc/src/lib/server-action/server.tsx
@@ -1,0 +1,40 @@
+import { tinyassert } from "@hiogawa/utils";
+import ReactServer from "react-server-dom-webpack/server.edge";
+import { getServerManifest } from "../server-manifest";
+
+export type ActionResult = unknown;
+
+export async function actionHandler(request: Request): Promise<ActionResult> {
+	const url = new URL(request.url);
+	const { serverManifest } = await getServerManifest();
+	let boundAction: Function;
+	if (url.searchParams.has("__f")) {
+		// client stream request
+		const contentType = request.headers.get("content-type");
+		const body = contentType?.startsWith("multipart/form-data")
+			? await request.formData()
+			: await request.text();
+		const args = await ReactServer.decodeReply(body);
+		const $$id = url.searchParams.get("__a");
+		tinyassert($$id);
+		const entry = serverManifest[$$id];
+		// @ts-expect-error
+		const mod = __webpack_require__(entry.id);
+		// TODO: export tree shaken...
+		console.log({ $$id, entry, mod });
+		boundAction = () => mod[entry.name](...args);
+	} else {
+		// progressive enhancement
+		const formData = await request.formData();
+		const decodedAction = await ReactServer.decodeAction(
+			formData,
+			serverManifest,
+		);
+		boundAction = async () => {
+			const result = await decodedAction();
+			const formState = await ReactServer.decodeFormState(result, formData);
+			return formState;
+		};
+	}
+	return boundAction();
+}

--- a/webpack-rsc/src/lib/server-action/ssr.tsx
+++ b/webpack-rsc/src/lib/server-action/ssr.tsx
@@ -1,0 +1,5 @@
+import ReactClient from "react-server-dom-webpack/client.edge";
+
+export function createServerReference(id: string, name: string) {
+	return ReactClient.createServerReference(id + "#" + name, () => {});
+}

--- a/webpack-rsc/src/lib/server-manifest.ts
+++ b/webpack-rsc/src/lib/server-manifest.ts
@@ -1,0 +1,28 @@
+import { tinyassert } from "@hiogawa/utils";
+import type { BundlerConfig, ImportManifestEntry } from "../types/react-types";
+import type { ReferenceMap } from "./client-manifest";
+
+export async function getServerManifest() {
+	const { default: serverRefs }: { default: ReferenceMap } = await import(
+		/* webpackIgnore: true */ "./__server_reference.js" as string
+	);
+
+	const serverManifest: BundlerConfig = new Proxy(
+		{},
+		{
+			get(_target, $$id, _receiver) {
+				tinyassert(typeof $$id === "string");
+				const [resource, name] = $$id.split("#");
+				const entry = serverRefs[resource];
+				tinyassert(entry, `invalid server reference '${resource}'`);
+				return {
+					id: entry.id,
+					name,
+					chunks: [],
+				} satisfies ImportManifestEntry;
+			},
+		},
+	);
+
+	return { serverManifest };
+}

--- a/webpack-rsc/src/lib/webpack/loader-client-use-server.js
+++ b/webpack-rsc/src/lib/webpack/loader-client-use-server.js
@@ -20,7 +20,7 @@ export default async function loader(input) {
 
 	serverReferences.add(this.resourcePath);
 	const id = this.resourcePath; // TODO: obfuscate id
-	const matches = input.matchAll(/export function (\w+)\(/g);
+	const matches = input.matchAll(/export\s+(?:async)?\s+function\s+(\w+)\(/g);
 	const exportNames = [...matches].map((m) => m[1]);
 	let output = `import { createServerReference as $$proxy } from "${path.resolve(runtime)}";\n`;
 	for (const name of exportNames) {

--- a/webpack-rsc/src/lib/webpack/loader-client-use-server.js
+++ b/webpack-rsc/src/lib/webpack/loader-client-use-server.js
@@ -1,0 +1,34 @@
+import path from "node:path";
+import { exportExpr } from "./loader-server-use-client.js";
+
+/**
+ * @typedef {{ serverReferences: Set<string>, runtime: string }} LoaderOptions
+ */
+
+/**
+ * @type {import("webpack").LoaderDefinitionFunction<LoaderOptions, {}>}
+ */
+export default async function loader(input) {
+	const callback = this.async();
+	const { serverReferences, runtime } = this.getOptions();
+	serverReferences.delete(this.resourcePath);
+
+	if (!/^("use server"|'use server')/m.test(input)) {
+		callback(null, input);
+		return;
+	}
+
+	serverReferences.add(this.resourcePath);
+	const id = this.resourcePath; // TODO: obfuscate id
+	const matches = input.matchAll(/export function (\w+)\(/g);
+	const exportNames = [...matches].map((m) => m[1]);
+	let output = `import { createServerReference as $$proxy } from "${path.resolve(runtime)}";\n`;
+	for (const name of exportNames) {
+		output +=
+			exportExpr(
+				name,
+				`$$proxy(${JSON.stringify(id)}, ${JSON.stringify(name)})`,
+			) + ";\n";
+	}
+	callback(null, output);
+}

--- a/webpack-rsc/src/lib/webpack/loader-server-use-client.js
+++ b/webpack-rsc/src/lib/webpack/loader-server-use-client.js
@@ -38,7 +38,7 @@ export default async function loader(input) {
  * @param {string} name
  * @param {string} expr
  */
-function exportExpr(name, expr) {
+export function exportExpr(name, expr) {
 	return name === "default"
 		? `export default ${expr}`
 		: `export const ${name} = ${expr}`;

--- a/webpack-rsc/src/routes/_client.tsx
+++ b/webpack-rsc/src/routes/_client.tsx
@@ -23,3 +23,7 @@ function useHydrated() {
 		() => false,
 	);
 }
+
+export function TestHydrated() {
+	return <span id="hydrated" data-hydrated={useHydrated()} />;
+}

--- a/webpack-rsc/src/routes/_client.tsx
+++ b/webpack-rsc/src/routes/_client.tsx
@@ -25,5 +25,5 @@ function useHydrated() {
 }
 
 export function TestHydrated() {
-	return <span id="hydrated" data-hydrated={useHydrated()} />;
+	return <meta name="x-hydrated" data-hydrated={useHydrated()} />;
 }

--- a/webpack-rsc/src/routes/action/_action.tsx
+++ b/webpack-rsc/src/routes/action/_action.tsx
@@ -1,0 +1,11 @@
+"use server";
+
+import { tinyassert } from "@hiogawa/utils";
+
+export let count = 0;
+
+export function changeCount(formData: FormData) {
+	const change = Number(formData.get("change"));
+	tinyassert(Number.isSafeInteger(change));
+	count += change;
+}

--- a/webpack-rsc/src/routes/action/_action.tsx
+++ b/webpack-rsc/src/routes/action/_action.tsx
@@ -4,8 +4,10 @@ import { tinyassert } from "@hiogawa/utils";
 
 export let count = 0;
 
-export function changeCount(formData: FormData) {
+export async function changeCount(_: unknown, formData: FormData) {
+	await new Promise((r) => setTimeout(r, 500));
 	const change = Number(formData.get("change"));
 	tinyassert(Number.isSafeInteger(change));
 	count += change;
+	return { count, change };
 }

--- a/webpack-rsc/src/routes/action/_client.tsx
+++ b/webpack-rsc/src/routes/action/_client.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { changeCount } from "./_action";
+
+export function ServerCounter(props: { value: number }) {
+	return (
+		<form action={changeCount}>
+			<div style={{ marginBottom: "0.5rem" }}>Count is {props.value}</div>
+			<div style={{ display: "flex", placeContent: "center", gap: "0.5rem" }}>
+				<button name="change" value="-1">
+					-1
+				</button>
+				<button name="change" value="+1">
+					+1
+				</button>
+			</div>
+		</form>
+	);
+}

--- a/webpack-rsc/src/routes/action/_client.tsx
+++ b/webpack-rsc/src/routes/action/_client.tsx
@@ -1,10 +1,16 @@
 "use client";
 
+import React from "react";
 import { changeCount } from "./_action";
 
 export function ServerCounter(props: { value: number }) {
+	const [state, formAction, isPending] = React.useActionState(
+		changeCount,
+		null,
+	);
+
 	return (
-		<form action={changeCount}>
+		<form action={formAction}>
 			<div style={{ marginBottom: "0.5rem" }}>Count is {props.value}</div>
 			<div style={{ display: "flex", placeContent: "center", gap: "0.5rem" }}>
 				<button name="change" value="-1">
@@ -14,6 +20,11 @@ export function ServerCounter(props: { value: number }) {
 					+1
 				</button>
 			</div>
+			<pre>
+				state = {JSON.stringify(state)}
+				<br />
+				{`isPending = ${String(isPending).padEnd(5, " ")}`}
+			</pre>
 		</form>
 	);
 }

--- a/webpack-rsc/src/routes/action/page.tsx
+++ b/webpack-rsc/src/routes/action/page.tsx
@@ -1,0 +1,11 @@
+import { count } from "./_action";
+import { ServerCounter } from "./_client";
+
+export default function Page() {
+	return (
+		<div>
+			<h3>Server Action</h3>
+			<ServerCounter value={count} />
+		</div>
+	);
+}

--- a/webpack-rsc/src/routes/layout.tsx
+++ b/webpack-rsc/src/routes/layout.tsx
@@ -22,6 +22,7 @@ export default function Layout(props: React.PropsWithChildren) {
 				>
 					Menu:
 					<a href="/">Home</a>
+					<a href="/action">Action</a>
 					<a href="/stream">Stream</a>
 					<a href="/error">Error</a>
 				</div>

--- a/webpack-rsc/src/routes/layout.tsx
+++ b/webpack-rsc/src/routes/layout.tsx
@@ -1,4 +1,5 @@
 import type React from "react";
+import { TestHydrated } from "./_client";
 import css from "./_style.css?raw";
 
 export default function Layout(props: React.PropsWithChildren) {
@@ -10,6 +11,7 @@ export default function Layout(props: React.PropsWithChildren) {
 				<link rel="icon" type="image/x-icon" href="/favicon.ico" />
 				<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 				<style>{css}</style>
+				<TestHydrated />
 			</head>
 			<body>
 				<div

--- a/webpack-rsc/src/routes/stream/_client3.tsx
+++ b/webpack-rsc/src/routes/stream/_client3.tsx
@@ -1,5 +1,5 @@
 "use client";
 
 export function Client3() {
-	return <span style={{ display: "none" }}>test-client2</span>;
+	return <span style={{ display: "none" }}>test-client3</span>;
 }

--- a/webpack-rsc/src/types/react-types.ts
+++ b/webpack-rsc/src/types/react-types.ts
@@ -21,3 +21,5 @@ export interface SsrManifest {
 	// TODO
 	moduleLoading: null;
 }
+
+export type CallServerCallback = (id: string, args: unknown[]) => unknown;

--- a/webpack-rsc/src/types/react.d.ts
+++ b/webpack-rsc/src/types/react.d.ts
@@ -56,20 +56,20 @@ declare module "react-server-dom-webpack/client.edge" {
 declare module "react-server-dom-webpack/client.browser" {
 	export function createServerReference(
 		id: string,
-		callServer: unknown,
+		callServer: import("./react-types").CallServerCallback,
 	): Function;
 
 	export function createFromReadableStream<T>(
 		stream: ReadableStream<Uint8Array>,
 		options: {
-			callServer: unknown;
+			callServer: import("./react-types").CallServerCallback;
 		},
 	): Promise<T>;
 
 	export function createFromFetch<T>(
 		promiseForResponse: Promise<Response>,
 		options: {
-			callServer: unknown;
+			callServer: import("./react-types").CallServerCallback;
 		},
 	): Promise<T>;
 

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -154,14 +154,14 @@ export default function (env, _argv) {
 						}
 					});
 
+					// generate client manifest
 					compiler.hooks.thisCompilation.tap(NAME, (compilation) => {
-						// generate client manifest and server manifest
-						compilation.hooks.processAssets.tapPromise(
+						compilation.hooks.processAssets.tap(
 							{
 								name: NAME,
-								stage: webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
+								stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
 							},
-							async () => {
+							() => {
 								const clientMap = processReferences(
 									compilation,
 									clientReferences,

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -148,57 +148,18 @@ export default function (env, _argv) {
 				apply(compiler) {
 					const NAME = /** @type {any} */ (this).name;
 
+					// inject discovered client references to ssr entries
+					// cf. FlightClientEntryPlugin.injectClientEntryAndSSRModules
+					// https://github.com/vercel/next.js/blob/cbbe586f2fa135ad5859ae6c38ac879c086927ef/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts#L747
+					compiler.hooks.finishMake.tapPromise(NAME, async (compilation) => {
+						for (const reference of clientReferences) {
+							await includeReference(compilation, reference, {
+								layer: LAYER.ssr,
+							});
+						}
+					});
+
 					compiler.hooks.thisCompilation.tap(NAME, (compilation) => {
-						// inject discovered client references as ssr entries
-						// and server references as server entries
-						let needAdditional = false;
-						let lastClientReferences = new Set(clientReferences);
-						let lastServerReferences = new Set(serverReferences);
-
-						compilation.hooks.needAdditionalSeal.tap(
-							NAME,
-							() => needAdditional,
-						);
-
-						compilation.hooks.processAssets.tapPromise(
-							{
-								name: NAME,
-								stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
-							},
-							async () => {
-								console.log("[processAssets]", {
-									lastClientReferences,
-									lastServerReferences,
-									clientReferences,
-									serverReferences,
-								});
-								const newClientReferences = difference(
-									[...clientReferences],
-									[...lastClientReferences],
-								);
-								const newServerReferences = difference(
-									[...serverReferences],
-									[...lastServerReferences],
-								);
-								lastClientReferences = new Set(clientReferences);
-								lastServerReferences = new Set(serverReferences);
-								needAdditional =
-									newClientReferences.length > 0 ||
-									newServerReferences.length > 0;
-								for (const reference of newClientReferences) {
-									await includeReference(compilation, reference, {
-										layer: LAYER.ssr,
-									});
-								}
-								// TODO: entry is already included in LAYER.ssr ?
-								// for (const reference of newServerReferences) {
-								// 	await includeReference(compilation, reference, {
-								// 		layer: LAYER.server,
-								// 	});
-								// }
-							},
-						);
-
 						// generate client manifest and server manifest
 						compilation.hooks.processAssets.tapPromise(
 							{
@@ -206,23 +167,11 @@ export default function (env, _argv) {
 								stage: webpack.Compilation.PROCESS_ASSETS_STAGE_SUMMARIZE,
 							},
 							async () => {
-								if (needAdditional) return;
-
 								const clientMap = processReferences(
 									compilation,
 									clientReferences,
 									LAYER.ssr,
 								);
-								// TODO
-								console.log("[__client_reference_ssr]", {
-									clientReferences,
-									clientMap,
-									debug: processReferences(
-										compilation,
-										clientReferences,
-										LAYER.server,
-									),
-								});
 								compilation.emitAsset(
 									"__client_reference_ssr.js",
 									new webpack.sources.RawSource(
@@ -235,16 +184,6 @@ export default function (env, _argv) {
 									serverReferences,
 									LAYER.server,
 								);
-								// TODO
-								console.log("[__server_reference]", {
-									serverReferences,
-									serverMap,
-									debug: processReferences(
-										compilation,
-										serverReferences,
-										LAYER.ssr,
-									),
-								});
 								compilation.emitAsset(
 									"__server_reference.js",
 									new webpack.sources.RawSource(

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -1,12 +1,7 @@
 import { cpSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
-import {
-	createManualPromise,
-	difference,
-	tinyassert,
-	uniq,
-} from "@hiogawa/utils";
+import { createManualPromise, tinyassert, uniq } from "@hiogawa/utils";
 import { webToNodeHandler } from "@hiogawa/utils-node";
 import webpack from "webpack";
 

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -91,6 +91,7 @@ export default function (env, _argv) {
 		optimization: {
 			minimize: false,
 			concatenateModules: false,
+			usedExports: false,
 		},
 		// TODO: https://webpack.js.org/configuration/externals
 		externals: {},


### PR DESCRIPTION
Let's just do the simplest one where client component importing `"use server"` file.

- [ ] bundler things
  - [x] loader for ssr and brower
  - [ ] dynamic server entry via `finishMake` (TODO)
    - `finishMake` cannot solve https://github.com/hi-ogawa/vite-plugins/pull/323? maybe need to loop via `compilation.needAdditionalPass`?
  - [x] server manifest
  - [ ] build
    - ensure not tree-shaken?
    - module id becomes null when the module is concated?
    - for now disable optimization
- [x] react things
  - [x] server handler
  - [x] browser call server
  - [x] formState
- [x] test