### PR TITLE
fix(webpack-rsc): use loader to inject browser client reference chunks

### DIFF
--- a/webpack-rsc/README.md
+++ b/webpack-rsc/README.md
@@ -11,10 +11,8 @@ Minimal RSC demo on Webpack
 - [x] flight server
 - [x] ssr
 - [x] browser
-- [x] client reference
-- [x] client side navigation
-- [ ] fs routes
-- [ ] server reference
-- [ ] styles
+- [x] client reference (minimal)
+- [ ] server reference (minimal)
+- [ ] css
 - [ ] server hmr
 - [ ] client hmr

--- a/webpack-rsc/README.md
+++ b/webpack-rsc/README.md
@@ -11,8 +11,10 @@ Minimal RSC demo on Webpack
 - [x] flight server
 - [x] ssr
 - [x] browser
-- [x] client reference (minimal)
-- [ ] server reference (minimal)
-- [ ] css
+- [x] client reference
+- [x] client side navigation
+- [ ] fs routes
+- [ ] server reference
+- [ ] styles
 - [ ] server hmr
 - [ ] client hmr

--- a/webpack-rsc/src/lib/webpack/loader-inject-client-references.js
+++ b/webpack-rsc/src/lib/webpack/loader-inject-client-references.js
@@ -1,0 +1,16 @@
+// TODO: use virtual module?
+
+/**
+ * @typedef {{ clientReferences: Set<string> }} LoaderOptions
+ */
+
+/**
+ * @type {import("webpack").LoaderDefinitionFunction<LoaderOptions, {}>}
+ */
+export default async function loader(input) {
+	const { clientReferences } = this.getOptions();
+	input += [...clientReferences]
+		.map((file) => `() => import(${JSON.stringify(file)})`)
+		.join(";\n");
+	return input;
+}

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -251,6 +251,22 @@ export default function (env, _argv) {
 			filename: dev ? "[name].js" : "[name].[contenthash:8].js",
 			clean: true,
 		},
+		module: {
+			rules: [
+				{
+					test: path.resolve("./src/entry-browser.tsx"),
+					use: {
+						loader: path.resolve(
+							"./src/lib/webpack/loader-inject-client-references.js",
+						),
+						options: {
+							clientReferences,
+						},
+					},
+				},
+				...commonConfig.module.rules,
+			],
+		},
 		plugins: [
 			new webpack.DefinePlugin({
 				"__define.SSR": "false",
@@ -260,17 +276,6 @@ export default function (env, _argv) {
 				name: "client-reference:browser",
 				apply(compiler) {
 					const NAME = /** @type {any} */ (this).name;
-
-					// include client reference chunks
-					compiler.hooks.make.tapPromise(NAME, async (compilation) => {
-						let i = 0;
-						for (const reference of clientReferences) {
-							includeReference(compilation, reference, {
-								name: `ref${i++}`,
-								dependOn: ["index"],
-							});
-						}
-					});
 
 					// generate client manifest
 					// https://github.com/unstubbable/mfng/blob/251b5284ca6f10b4c46e16833dacf0fd6cf42b02/packages/webpack-rsc/src/webpack-rsc-client-plugin.ts#L193


### PR DESCRIPTION
It seems like relying on compilation API wizardly was too early and it's breaking https://github.com/hi-ogawa/experiments/pull/30 for some reason.
Let's just get back to simple dynamic import injection to get code split like initially done in https://github.com/hi-ogawa/experiments/pull/23