### PR TITLE
fix(webpack-rsc): robust client/server reference module generation

### DIFF
--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -283,7 +283,8 @@ export default function (env, _argv) {
 			clean: true,
 		},
 		optimization: {
-			concatenateModules: false,
+			// for debugging
+			// minimize: false,
 		},
 		module: {
 			rules: [
@@ -330,10 +331,9 @@ export default function (env, _argv) {
 						const data = {};
 
 						for (const mod of compilation.modules) {
-							if (
-								mod instanceof webpack.NormalModule &&
-								clientReferences.has(mod.resource)
-							) {
+							// module can be either NormalModule or ConcatenatedModule
+							const name = mod.nameForCondition();
+							if (typeof name === "string" && clientReferences.has(name)) {
 								const mods = collectModuleDeps(compilation, mod);
 								const chunks = uniq(
 									[...mods].flatMap((mod) => [
@@ -349,7 +349,7 @@ export default function (env, _argv) {
 										}
 									}
 								}
-								data[mod.resource] = {
+								data[name] = {
 									id: compilation.chunkGraph.getModuleId(mod),
 									chunks: chunkIds,
 								};
@@ -397,13 +397,10 @@ function processReferences(compilation, selected, layer) {
 	/** @type {import("./src/lib/client-manifest").ReferenceMap} */
 	const result = {};
 	for (const mod of compilation.modules) {
-		if (
-			mod instanceof webpack.NormalModule &&
-			selected.has(mod.resource) &&
-			mod.layer === layer
-		) {
+		const name = mod.nameForCondition();
+		if (typeof name === "string" && selected.has(name) && mod.layer === layer) {
 			const id = compilation.chunkGraph.getModuleId(mod);
-			result[mod.resource] = { id, chunks: [] };
+			result[name] = { id, chunks: [] };
 		}
 	}
 	return result;

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -145,13 +145,11 @@ export default function (env, _argv) {
 					// cf. FlightClientEntryPlugin.injectClientEntryAndSSRModules
 					// https://github.com/vercel/next.js/blob/cbbe586f2fa135ad5859ae6c38ac879c086927ef/packages/next/src/build/webpack/plugins/flight-client-entry-plugin.ts#L747
 					compiler.hooks.finishMake.tapPromise(NAME, async (compilation) => {
+						// server references are discovered when including client reference modules
+						// so the order matters
 						for (const reference of clientReferences) {
 							await includeReference(compilation, reference, LAYER.ssr);
 						}
-						// TODO: auto discovered server references
-						serverReferences.add(
-							path.resolve("./src/routes/action/_action.tsx"),
-						);
 						for (const reference of serverReferences) {
 							await includeReference(compilation, reference, LAYER.server);
 						}


### PR DESCRIPTION
It looks like `mod instanceof NormalModule` is failing when concatenated since it's `ConcatenatedModule`.

Also, I have no idea but replacing `addInclude(... { layer })` with `addModuleTree(... { issuerLayer })` seems to help.

## todo

- [x] browser build
- [x] server build