### PR TITLE
fix(webpack-rsc): normalize and obfuscate reference id

### DIFF
--- a/webpack-rsc/src/lib/build-manager.js
+++ b/webpack-rsc/src/lib/build-manager.js
@@ -1,6 +1,6 @@
 export class BuildManager {
 	// keep mapping of
-	//   module name (abs path) => client id (rel path)
+	//   module name (absolute path) => client id (hashed relative path)
 
 	/** @type {Record<string, string>} */
 	clientReferenceMap = {};

--- a/webpack-rsc/src/lib/build-manager.js
+++ b/webpack-rsc/src/lib/build-manager.js
@@ -1,8 +1,5 @@
 export class BuildManager {
 	/** @type {Set<string>} */
-	clientReferences = new Set();
-
-	/** @type {Set<string>} */
 	serverReferences = new Set();
 
 	/**

--- a/webpack-rsc/src/lib/build-manager.js
+++ b/webpack-rsc/src/lib/build-manager.js
@@ -4,4 +4,10 @@ export class BuildManager {
 
 	/** @type {Set<string>} */
 	serverReferences = new Set();
+
+	/**
+	 * module name (abs path) -> client id (rel path)
+	 * @type {Record<string, string>}
+	 */
+	clientReferenceMap = {};
 }

--- a/webpack-rsc/src/lib/build-manager.js
+++ b/webpack-rsc/src/lib/build-manager.js
@@ -1,0 +1,7 @@
+export class BuildManager {
+	/** @type {Set<string>} */
+	clientReferences = new Set();
+
+	/** @type {Set<string>} */
+	serverReferences = new Set();
+}

--- a/webpack-rsc/src/lib/build-manager.js
+++ b/webpack-rsc/src/lib/build-manager.js
@@ -1,10 +1,10 @@
 export class BuildManager {
-	/** @type {Set<string>} */
-	serverReferences = new Set();
+	// keep mapping of
+	//   module name (abs path) => client id (rel path)
 
-	/**
-	 * module name (abs path) -> client id (rel path)
-	 * @type {Record<string, string>}
-	 */
+	/** @type {Record<string, string>} */
 	clientReferenceMap = {};
+
+	/** @type {Record<string, string>} */
+	serverReferenceMap = {};
 }

--- a/webpack-rsc/src/lib/webpack/loader-client-use-server.js
+++ b/webpack-rsc/src/lib/webpack/loader-client-use-server.js
@@ -2,7 +2,7 @@ import path from "node:path";
 import { exportExpr } from "./loader-server-use-client.js";
 
 /**
- * @typedef {{ serverReferences: Set<string>, runtime: string }} LoaderOptions
+ * @typedef {{ manager: import("../build-manager.js").BuildManager, runtime: string }} LoaderOptions
  */
 
 /**
@@ -10,15 +10,15 @@ import { exportExpr } from "./loader-server-use-client.js";
  */
 export default async function loader(input) {
 	const callback = this.async();
-	const { serverReferences, runtime } = this.getOptions();
-	serverReferences.delete(this.resourcePath);
+	const { manager, runtime } = this.getOptions();
+	manager.serverReferences.delete(this.resourcePath);
 
 	if (!/^("use server"|'use server')/m.test(input)) {
 		callback(null, input);
 		return;
 	}
 
-	serverReferences.add(this.resourcePath);
+	manager.serverReferences.add(this.resourcePath);
 	const id = this.resourcePath; // TODO: obfuscate id
 	const matches = input.matchAll(/export\s+(?:async)?\s+function\s+(\w+)\(/g);
 	const exportNames = [...matches].map((m) => m[1]);

--- a/webpack-rsc/src/lib/webpack/loader-client-use-server.js
+++ b/webpack-rsc/src/lib/webpack/loader-client-use-server.js
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import path from "node:path";
 import { tinyassert } from "@hiogawa/utils";
 import { exportExpr } from "./loader-server-use-client.js";
@@ -25,8 +26,9 @@ export default async function loader(input) {
 		return;
 	}
 
+	// TODO: obfuscate export names too?
 	tinyassert(this._compiler);
-	const serverId = path.relative(this._compiler.context, modName);
+	const serverId = hashString(path.relative(this._compiler.context, modName));
 	manager.serverReferenceMap[modName] = serverId;
 
 	const matches = input.matchAll(/export\s+(?:async)?\s+function\s+(\w+)\(/g);
@@ -40,4 +42,12 @@ export default async function loader(input) {
 			) + ";\n";
 	}
 	callback(null, output);
+}
+
+/**
+ *
+ * @param {string} value
+ */
+function hashString(value) {
+	return crypto.createHash("sha256").update(value).digest().toString("hex");
 }

--- a/webpack-rsc/src/lib/webpack/loader-server-use-client.js
+++ b/webpack-rsc/src/lib/webpack/loader-server-use-client.js
@@ -1,7 +1,7 @@
 // TODO: use https://github.com/hi-ogawa/vite-plugins/tree/main/packages/transforms
 
 /**
- * @typedef {{ clientReferences: Set<string> }} LoaderOptions
+ * @typedef {{ manager: import("../build-manager.js").BuildManager }} LoaderOptions
  */
 
 /**
@@ -9,8 +9,8 @@
  */
 export default async function loader(input) {
 	const callback = this.async();
-	const { clientReferences } = this.getOptions();
-	clientReferences.delete(this.resourcePath);
+	const { manager } = this.getOptions();
+	manager.clientReferences.delete(this.resourcePath);
 
 	// "use strict" injected by other loaders?
 	if (!/^("use client"|'use client')/m.test(input)) {
@@ -18,7 +18,7 @@ export default async function loader(input) {
 		return;
 	}
 
-	clientReferences.add(this.resourcePath);
+	manager.clientReferences.add(this.resourcePath);
 	const id = this.resourcePath; // TODO: obfuscate id
 	const matches = input.matchAll(/export function (\w+)\(/g);
 	const exportNames = [...matches].map((m) => m[1]);

--- a/webpack-rsc/src/lib/webpack/loader-server-use-client.js
+++ b/webpack-rsc/src/lib/webpack/loader-server-use-client.js
@@ -19,9 +19,7 @@ export default async function loader(input) {
 		callback(null, input);
 		return;
 	}
-
 	delete manager.clientReferenceMap[modName];
-	manager.clientReferences.delete(this.resourcePath);
 
 	// "use strict" injected by other loaders?
 	if (!/^("use client"|'use client')/m.test(input)) {
@@ -32,7 +30,6 @@ export default async function loader(input) {
 	tinyassert(this._compiler);
 	const clientId = path.relative(this._compiler.context, modName);
 	manager.clientReferenceMap[modName] = clientId;
-	manager.clientReferences.add(this.resourcePath);
 	const matches = input.matchAll(/export function (\w+)\(/g);
 	const exportNames = [...matches].map((m) => m[1]);
 	let output = `import { registerClientReference as $$register } from "react-server-dom-webpack/server.edge";\n`;

--- a/webpack-rsc/src/lib/webpack/loader-server-use-client.js
+++ b/webpack-rsc/src/lib/webpack/loader-server-use-client.js
@@ -12,13 +12,13 @@ import { tinyassert } from "@hiogawa/utils";
  */
 export default async function loader(input) {
 	const callback = this.async();
-	const { manager } = this.getOptions();
-
 	const modName = this._module?.nameForCondition();
 	if (!modName) {
 		callback(null, input);
 		return;
 	}
+
+	const { manager } = this.getOptions();
 	delete manager.clientReferenceMap[modName];
 
 	// "use strict" injected by other loaders?
@@ -30,6 +30,7 @@ export default async function loader(input) {
 	tinyassert(this._compiler);
 	const clientId = path.relative(this._compiler.context, modName);
 	manager.clientReferenceMap[modName] = clientId;
+
 	const matches = input.matchAll(/export function (\w+)\(/g);
 	const exportNames = [...matches].map((m) => m[1]);
 	let output = `import { registerClientReference as $$register } from "react-server-dom-webpack/server.edge";\n`;

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -4,7 +4,7 @@ import path from "node:path";
 import { createManualPromise, tinyassert, uniq } from "@hiogawa/utils";
 import { webToNodeHandler } from "@hiogawa/utils-node";
 import webpack from "webpack";
-import { BuildManager } from "./src/lib/build-manager";
+import { BuildManager } from "./src/lib/build-manager.js";
 
 // SSR setup is based on
 // https://github.com/hi-ogawa/reproductions/tree/main/webpack-react-ssr

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -145,7 +145,7 @@ export default function (env, _argv) {
 					compiler.hooks.finishMake.tapPromise(NAME, async (compilation) => {
 						// server references are discovered when including client reference modules
 						// so the order matters
-						for (const reference of manager.clientReferences) {
+						for (const reference in manager.clientReferenceMap) {
 							await includeReference(compilation, reference, LAYER.ssr);
 						}
 						for (const reference of manager.serverReferences) {
@@ -257,7 +257,7 @@ export default function (env, _argv) {
 					// https://webpack.js.org/api/compiler-hooks/
 					compiler.hooks.invalid.tap(NAME, () => {
 						// TODO: when to invalidate client references?
-						manager.clientReferences;
+						manager.clientReferenceMap;
 
 						// invalidate all server cjs
 						for (const key in require.cache) {
@@ -307,7 +307,7 @@ export default function (env, _argv) {
 							getCode: () => {
 								return [
 									`export default [`,
-									...[...manager.clientReferences].map(
+									...Object.keys(manager.clientReferenceMap).map(
 										(file) => `() => import(${JSON.stringify(file)}),`,
 									),
 									`]`,

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -148,7 +148,7 @@ export default function (env, _argv) {
 						for (const reference in manager.clientReferenceMap) {
 							await includeReference(compilation, reference, LAYER.ssr);
 						}
-						for (const reference of manager.serverReferences) {
+						for (const reference in manager.serverReferenceMap) {
 							await includeReference(compilation, reference, LAYER.server);
 						}
 					});
@@ -177,11 +177,9 @@ export default function (env, _argv) {
 											chunks: [],
 										};
 									}
-									if (
-										manager.serverReferences.has(modName) &&
-										mod.layer === LAYER.server
-									) {
-										serverMap[modName] = {
+									const serverId = manager.serverReferenceMap[modName];
+									if (serverId && mod.layer === LAYER.server) {
+										serverMap[serverId] = {
 											id: compilation.chunkGraph.getModuleId(mod),
 											chunks: [],
 										};

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -322,7 +322,7 @@ export default function (env, _argv) {
 						),
 						options: {
 							runtime: path.resolve("./src/lib/server-action/browser"),
-							serverReferences: new Set(),
+							manager,
 						},
 					},
 				},

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -305,8 +305,9 @@ export default function (env, _argv) {
 							getCode: () => {
 								return [
 									`export default [`,
-									...Object.keys(manager.clientReferenceMap).map(
-										(file) => `() => import(${JSON.stringify(file)}),`,
+									...Object.values(manager.clientReferenceMap).map(
+										(file) =>
+											`() => import(${JSON.stringify(path.join("../..", file))}),`,
 									),
 									`]`,
 								].join("\n");


### PR DESCRIPTION
Currently absolute path shows up in source code, so we should make it relative from `compiler.context`.

Also, server action filename shows up as id, so it needs to be obfuscated.
Client reference id is already obfuscated since it's production module id.