### PR TITLE
fix(webpack-rsc): use cjs to invalidate derived assets

### DIFF
--- a/webpack-rsc/src/lib/client-assets.ts
+++ b/webpack-rsc/src/lib/client-assets.ts
@@ -2,9 +2,8 @@ import { tinyassert } from "@hiogawa/utils";
 import type { StatsCompilation } from "webpack";
 
 export async function getClientAssets() {
-	// TODO: need to invalidate esm by `?t=...` or use cjs with `delete require.cache[...]`
-	const { default: stats }: { default: StatsCompilation } = await import(
-		/* webpackIgnore: true */ "./__client_stats.js" as string
+	const stats: StatsCompilation = require(
+		/* webpackIgnore: true */ "./__client_stats.cjs" as string,
 	);
 	tinyassert(stats.assetsByChunkName);
 

--- a/webpack-rsc/src/lib/client-manifest.ts
+++ b/webpack-rsc/src/lib/client-manifest.ts
@@ -15,11 +15,11 @@ export type ReferenceMap = {
 };
 
 export async function getClientManifest() {
-	const { default: browserRefs }: { default: ReferenceMap } = await import(
-		/* webpackIgnore: true */ "./__client_reference_browser.js" as string
+	const browserRefs: ReferenceMap = require(
+		/* webpackIgnore: true */ "./__client_reference_browser.cjs" as string,
 	);
-	const { default: ssrRefs }: { default: ReferenceMap } = await import(
-		/* webpackIgnore: true */ "./__client_reference_ssr.js" as string
+	const ssrRefs: ReferenceMap = require(
+		/* webpackIgnore: true */ "./__client_reference_ssr.cjs" as string,
 	);
 
 	const browserManifest: BundlerConfig = new Proxy(

--- a/webpack-rsc/src/lib/server-manifest.ts
+++ b/webpack-rsc/src/lib/server-manifest.ts
@@ -3,8 +3,8 @@ import type { BundlerConfig, ImportManifestEntry } from "../types/react-types";
 import type { ReferenceMap } from "./client-manifest";
 
 export async function getServerManifest() {
-	const { default: serverRefs }: { default: ReferenceMap } = await import(
-		/* webpackIgnore: true */ "./__server_reference.js" as string
+	const serverRefs: ReferenceMap = require(
+		/* webpackIgnore: true */ "./__server_reference.cjs" as string,
 	);
 
 	const serverManifest: BundlerConfig = new Proxy(

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -92,6 +92,12 @@ export default function (env, _argv) {
 		externals: {},
 		experiments: { layers: true },
 		module: {
+			parser: {
+				javascript: {
+					// https://webpack.js.org/configuration/module/#moduleparserjavascriptcommonjsmagiccomments
+					commonjsMagicComments: true,
+				},
+			},
 			rules: [
 				{
 					test: path.resolve("./src/entry-server-layer.tsx"),
@@ -191,15 +197,15 @@ export default function (env, _argv) {
 								}
 
 								compilation.emitAsset(
-									"__client_reference_ssr.js",
+									"__client_reference_ssr.cjs",
 									new webpack.sources.RawSource(
-										`export default ${JSON.stringify(clientMap, null, 2)}`,
+										`module.exports = ${JSON.stringify(clientMap, null, 2)}`,
 									),
 								);
 								compilation.emitAsset(
-									"__server_reference.js",
+									"__server_reference.cjs",
 									new webpack.sources.RawSource(
-										`export default ${JSON.stringify(serverMap, null, 2)}`,
+										`module.exports = ${JSON.stringify(serverMap, null, 2)}`,
 									),
 								);
 							},
@@ -378,8 +384,8 @@ export default function (env, _argv) {
 							}
 						}
 
-						const code = `export default ${JSON.stringify(data, null, 2)}`;
-						writeFileSync("./dist/server/__client_reference_browser.js", code);
+						const code = `module.exports = ${JSON.stringify(data, null, 2)}`;
+						writeFileSync("./dist/server/__client_reference_browser.cjs", code);
 					});
 				},
 			},
@@ -389,8 +395,8 @@ export default function (env, _argv) {
 					const NAME = /** @type {any} */ (this).name;
 					compiler.hooks.done.tap(NAME, (stats) => {
 						const statsJson = stats.toJson({ chunks: false, modules: false });
-						const code = `export default ${JSON.stringify(statsJson, null, 2)}`;
-						writeFileSync("./dist/server/__client_stats.js", code);
+						const code = `module.exports = ${JSON.stringify(statsJson, null, 2)}`;
+						writeFileSync("./dist/server/__client_stats.cjs", code);
 					});
 				},
 			},


### PR DESCRIPTION
We actually need to use cjs to be able to invalidate manifest during dev...