### PR TITLE
feat(oxc-rsc): support more functions

### DIFF
--- a/oxc-rsc/src/hoist.rs
+++ b/oxc-rsc/src/hoist.rs
@@ -31,115 +31,7 @@ impl<'a> HoistTransformer<'a> {
 }
 
 impl<'a> Traverse<'a> for HoistTransformer<'a> {
-    fn exit_statement(
-        &mut self,
-        stmt: &mut Statement<'a>,
-        ctx: &mut oxc_traverse::TraverseCtx<'a>,
-    ) {
-        match stmt {
-            Statement::FunctionDeclaration(node) => {
-                if let (Some(body), Some(name)) = (&node.body, &node.id) {
-                    // check "use server"
-                    if body
-                        .directives
-                        .iter()
-                        .any(|e| e.expression.value == self.directive)
-                    {
-                        let new_name = format!("$$hoist_{}", self.hoisted_functions.len());
-
-                        // $$register(...)
-                        let register_call = ctx.ast.call_expression(
-                            SPAN,
-                            ctx.ast.identifier_reference_expression(
-                                ctx.ast.identifier_reference(SPAN, &self.runtime),
-                            ),
-                            ctx.ast.new_vec_from_iter([
-                                Argument::from(ctx.ast.identifier_reference_expression(
-                                    ctx.ast.identifier_reference(SPAN, &new_name.clone()),
-                                )),
-                                Argument::from(ctx.ast.literal_string_expression(
-                                    ctx.ast.string_literal(SPAN, &self.id),
-                                )),
-                                Argument::from(ctx.ast.literal_string_expression(
-                                    ctx.ast.string_literal(SPAN, &new_name),
-                                )),
-                            ]),
-                            false,
-                            None,
-                        );
-
-                        // TODO: $$register(...).bind(...)
-
-                        // const <name> = $$register(...)
-                        let new_stmt =
-                            Statement::VariableDeclaration(ctx.ast.variable_declaration(
-                                SPAN,
-                                oxc::ast::ast::VariableDeclarationKind::Const,
-                                ctx.ast.new_vec_single(ctx.ast.variable_declarator(
-                                    SPAN,
-                                    oxc::ast::ast::VariableDeclarationKind::Const,
-                                    ctx.ast.binding_pattern(
-                                        ctx.ast.binding_pattern_identifier(name.clone()),
-                                        None,
-                                        false,
-                                    ),
-                                    Some(register_call),
-                                    true,
-                                )),
-                                Modifiers::empty(),
-                            ));
-
-                        //
-                        // create new function to be hoisted at the end
-                        //
-                        let Function {
-                            span,
-                            r#async,
-                            params,
-                            body,
-                            ..
-                        } = node.borrow_mut().deref_mut();
-                        // TODO: bind_vars
-                        let new_param_items = ctx.ast.copy(&params.items);
-                        let body = body.as_mut().unwrap();
-                        let new_func = ctx.ast.function(
-                            FunctionType::FunctionDeclaration,
-                            *span,
-                            Some(BindingIdentifier::new(SPAN, ctx.ast.new_atom(&new_name))),
-                            false,
-                            *r#async,
-                            None,
-                            ctx.ast.formal_parameters(
-                                params.span,
-                                FormalParameterKind::FormalParameter,
-                                new_param_items,
-                                None,
-                            ),
-                            Some(ctx.ast.function_body(
-                                body.span,
-                                ctx.ast.new_vec(),
-                                ctx.ast.move_statement_vec(&mut body.statements),
-                            )),
-                            None,
-                            None,
-                            Modifiers::empty(),
-                        );
-                        self.hoisted_functions
-                            .push(Statement::ExportNamedDeclaration(
-                                ctx.ast.plain_export_named_declaration_declaration(
-                                    SPAN,
-                                    Declaration::FunctionDeclaration(new_func),
-                                ),
-                            ));
-
-                        *stmt = new_stmt;
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
+    // Expression::ArrowFunctionExpression
     fn exit_expression(
         &mut self,
         expr: &mut Expression<'a>,
@@ -287,6 +179,116 @@ impl<'a> Traverse<'a> for HoistTransformer<'a> {
                         ));
 
                     *expr = new_expr;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Statement::FunctionDeclaration
+    fn exit_statement(
+        &mut self,
+        stmt: &mut Statement<'a>,
+        ctx: &mut oxc_traverse::TraverseCtx<'a>,
+    ) {
+        match stmt {
+            Statement::FunctionDeclaration(node) => {
+                if let (Some(body), Some(name)) = (&node.body, &node.id) {
+                    // check "use server"
+                    if body
+                        .directives
+                        .iter()
+                        .any(|e| e.expression.value == self.directive)
+                    {
+                        let new_name = format!("$$hoist_{}", self.hoisted_functions.len());
+
+                        // $$register(...)
+                        let register_call = ctx.ast.call_expression(
+                            SPAN,
+                            ctx.ast.identifier_reference_expression(
+                                ctx.ast.identifier_reference(SPAN, &self.runtime),
+                            ),
+                            ctx.ast.new_vec_from_iter([
+                                Argument::from(ctx.ast.identifier_reference_expression(
+                                    ctx.ast.identifier_reference(SPAN, &new_name.clone()),
+                                )),
+                                Argument::from(ctx.ast.literal_string_expression(
+                                    ctx.ast.string_literal(SPAN, &self.id),
+                                )),
+                                Argument::from(ctx.ast.literal_string_expression(
+                                    ctx.ast.string_literal(SPAN, &new_name),
+                                )),
+                            ]),
+                            false,
+                            None,
+                        );
+
+                        // TODO: $$register(...).bind(...)
+
+                        // const <name> = $$register(...)
+                        let new_stmt =
+                            Statement::VariableDeclaration(ctx.ast.variable_declaration(
+                                SPAN,
+                                oxc::ast::ast::VariableDeclarationKind::Const,
+                                ctx.ast.new_vec_single(ctx.ast.variable_declarator(
+                                    SPAN,
+                                    oxc::ast::ast::VariableDeclarationKind::Const,
+                                    ctx.ast.binding_pattern(
+                                        ctx.ast.binding_pattern_identifier(name.clone()),
+                                        None,
+                                        false,
+                                    ),
+                                    Some(register_call),
+                                    true,
+                                )),
+                                Modifiers::empty(),
+                            ));
+
+                        //
+                        // create new function to be hoisted at the end
+                        //
+                        let Function {
+                            span,
+                            r#async,
+                            params,
+                            body,
+                            ..
+                        } = node.borrow_mut().deref_mut();
+                        // TODO: bind_vars
+                        let new_param_items = ctx.ast.copy(&params.items);
+                        let body = body.as_mut().unwrap();
+                        let new_func = ctx.ast.function(
+                            FunctionType::FunctionDeclaration,
+                            *span,
+                            Some(BindingIdentifier::new(SPAN, ctx.ast.new_atom(&new_name))),
+                            false,
+                            *r#async,
+                            None,
+                            ctx.ast.formal_parameters(
+                                params.span,
+                                FormalParameterKind::FormalParameter,
+                                new_param_items,
+                                None,
+                            ),
+                            Some(ctx.ast.function_body(
+                                body.span,
+                                ctx.ast.new_vec(),
+                                ctx.ast.move_statement_vec(&mut body.statements),
+                            )),
+                            None,
+                            None,
+                            Modifiers::empty(),
+                        );
+                        self.hoisted_functions
+                            .push(Statement::ExportNamedDeclaration(
+                                ctx.ast.plain_export_named_declaration_declaration(
+                                    SPAN,
+                                    Declaration::FunctionDeclaration(new_func),
+                                ),
+                            ));
+
+                        *stmt = new_stmt;
+                    }
                 }
             }
             _ => {}

--- a/oxc-rsc/tests/hoist/top.js
+++ b/oxc-rsc/tests/hoist/top.js
@@ -1,26 +1,25 @@
 const x = "x";
 
-export const f = async () => {
+const f = async () => {
 	"use server";
 	return x;
 };
-// export async function f() {
-//   "use server";
-//   return x;
-// }
 
-export const g = async () => {};
-// export async function g() {}
+async function f2() {
+  "use server";
+  return x;
+}
 
-export const h = async (formData) => {
+const g = async () => {};
+
+async function g2() {}
+
+const h = async (formData) => {
 	"use server";
 	return formData.get(x);
 };
-// export async function h(formData) {
-//   "use server";
-//   return formData.get(x);
-// }
 
-// export default function w() {
-//   "use server";
-// }
+async function h2(formData) {
+  "use server";
+  return formData.get(x);
+}

--- a/oxc-rsc/tests/hoist/top.snap
+++ b/oxc-rsc/tests/hoist/top.snap
@@ -3,9 +3,12 @@ source: src/hoist.rs
 input_file: tests/hoist/top.js
 ---
 const x = 'x';
-export const f = $$register($$hoist_0, '<id>', '$$hoist_0');
-export const g = async () => {};
-export const h = $$register($$hoist_1, '<id>', '$$hoist_1');
+const f = $$register($$hoist_0, '<id>', '$$hoist_0');
+const f2 = $$register($$hoist_1, '<id>', '$$hoist_1');
+const g = async () => {};
+async function g2() {}
+const h = $$register($$hoist_1, '<id>', '$$hoist_1');
+const h2 = $$register($$hoist_2, '<id>', '$$hoist_2');
 export async function $$hoist_0() {
 	return x;
 }

--- a/oxc-rsc/tests/hoist/top.snap
+++ b/oxc-rsc/tests/hoist/top.snap
@@ -7,11 +7,17 @@ const f = $$register($$hoist_0, '<id>', '$$hoist_0');
 const f2 = $$register($$hoist_1, '<id>', '$$hoist_1');
 const g = async () => {};
 async function g2() {}
-const h = $$register($$hoist_1, '<id>', '$$hoist_1');
-const h2 = $$register($$hoist_2, '<id>', '$$hoist_2');
+const h = $$register($$hoist_2, '<id>', '$$hoist_2');
+const h2 = $$register($$hoist_3, '<id>', '$$hoist_3');
 export async function $$hoist_0() {
 	return x;
 }
-export async function $$hoist_1(formData) {
+export async function $$hoist_1() {
+	return x;
+}
+export async function $$hoist_2(formData) {
+	return formData.get(x);
+}
+export async function $$hoist_3(formData) {
 	return formData.get(x);
 }


### PR DESCRIPTION
- [x] `ArrowFunctionExpression`
- [ ] `FunctionExpression`
- [ ] `FunctionDeclaration`
- [ ] refactor
  - [ ] need to repeat mostly same things for three patterns. how to reuse some code?
  - [ ] robust scope analysis without `span` check?