### PR TITLE
fix(webpack-rsc): fix ssrManifest.moduleLoading

### DIFF
--- a/webpack-rsc/src/lib/client-manifest.ts
+++ b/webpack-rsc/src/lib/client-manifest.ts
@@ -70,7 +70,10 @@ export async function getClientManifest() {
 	);
 	const ssrManifest: SsrManifest = {
 		moduleMap: ssrModuleMap,
-		moduleLoading: null,
+		moduleLoading: {
+			prefix: "/assets/",
+			crossOrigin: null,
+		},
 	};
 
 	return { browserManifest, ssrManifest };

--- a/webpack-rsc/src/types/react-types.ts
+++ b/webpack-rsc/src/types/react-types.ts
@@ -18,8 +18,10 @@ export type ModuleMap = {
 
 export interface SsrManifest {
 	moduleMap: ModuleMap;
-	// TODO
-	moduleLoading: null;
+	moduleLoading: {
+		prefix: string;
+		crossOrigin: null;
+	};
 }
 
 export type CallServerCallback = (id: string, args: unknown[]) => unknown;


### PR DESCRIPTION
I thought this is for automatically `modulepreload`-ing chunks during ssr, but it doesn't seem the case?