### PR TITLE
refactor(rsbuild-ssr): simplify client asset stats

### DIFF
--- a/rsbuild-ssr/rsbuild.config.ts
+++ b/rsbuild-ssr/rsbuild.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig, type RequestHandler, type Rspack } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 import { webToNodeHandler } from "@hiogawa/utils-node";
+import { mkdirSync, writeFileSync } from "fs";
 
 export default defineConfig((env) => ({
 	plugins: [pluginReact()],
@@ -33,9 +34,17 @@ export default defineConfig((env) => ({
 				rspack: {
 					plugins: [
 						{
-							name: "",
+							name: "client-assets",
 							apply(compiler: Rspack.Compiler) {
-								compiler.hooks;
+								if (env.command !== "build") return;
+
+								const NAME = this.name;
+								compiler.hooks.done.tap(NAME, (stats) => {
+									const statsJson = stats.toJson({ all: false, assets: true });
+									const code = `export default ${JSON.stringify(statsJson, null, 2)}`;
+									mkdirSync("./dist", { recursive: true });
+									writeFileSync("./dist/__client_stats.mjs", code);
+								});
 							},
 						},
 					],

--- a/rsbuild-ssr/rsbuild.config.ts
+++ b/rsbuild-ssr/rsbuild.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig, type RequestHandler } from "@rsbuild/core";
+import { defineConfig, type RequestHandler, type Rspack } from "@rsbuild/core";
 import { pluginReact } from "@rsbuild/plugin-react";
 import { webToNodeHandler } from "@hiogawa/utils-node";
 
@@ -29,6 +29,18 @@ export default defineConfig((env) => ({
 							}
 						: undefined,
 			},
+			tools: {
+				rspack: {
+					plugins: [
+						{
+							name: "",
+							apply(compiler: Rspack.Compiler) {
+								compiler.hooks;
+							},
+						},
+					],
+				},
+			},
 		},
 		ssr: {
 			output: {
@@ -37,7 +49,7 @@ export default defineConfig((env) => ({
 					root: "dist/server",
 				},
 				filename: {
-					js: "index.cjs",
+					js: "[name].cjs",
 				},
 				minify: false,
 			},
@@ -48,6 +60,11 @@ export default defineConfig((env) => ({
 				define: {
 					"import.meta.env.DEV": env.command === "dev",
 					"import.meta.env.SSR": true,
+				},
+			},
+			tools: {
+				rspack: {
+					dependencies: ["web"],
 				},
 			},
 		},

--- a/rsbuild-ssr/src/entry-server.tsx
+++ b/rsbuild-ssr/src/entry-server.tsx
@@ -36,8 +36,7 @@ async function getStatsJson(): Promise<Rspack.StatsCompilation> {
 		return stats.toJson();
 	} else {
 		const { default: statsJson } = await import(
-			/* webpackIgnore: true */ "../client/stats.json" as string,
-			{ with: { type: "json" } }
+			/* webpackMode: "eager" */ "../dist/__client_stats.mjs" as string
 		);
 		return statsJson;
 	}


### PR DESCRIPTION
In-memory `environments.web.getStats` might not be useful since it'll create a different code path for dev/build anyways.