### PR TITLE
feat(viteroll): extract hmr chunk from normal build

### DIFF
--- a/viteroll/package.json
+++ b/viteroll/package.json
@@ -20,7 +20,7 @@
 		"@playwright/test": "^1.48.2",
 		"@types/node": "^22.8.5",
 		"preact": "^10.24.3",
-		"rolldown": "file:./rolldown-0.14.0.tgz",
+		"rolldown": "link:../../../others/rolldown/packages/rolldown",
 		"typescript": "^5.6.3",
 		"vite": "6.0.0-beta.8"
 	},

--- a/viteroll/package.json
+++ b/viteroll/package.json
@@ -20,7 +20,7 @@
 		"@playwright/test": "^1.48.2",
 		"@types/node": "^22.8.5",
 		"preact": "^10.24.3",
-		"rolldown": "0.13.2-snapshot-a292401-20241105072341",
+		"rolldown": "file:./rolldown-0.14.0.tgz",
 		"typescript": "^5.6.3",
 		"vite": "6.0.0-beta.8"
 	},

--- a/viteroll/package.json
+++ b/viteroll/package.json
@@ -20,7 +20,7 @@
 		"@playwright/test": "^1.48.2",
 		"@types/node": "^22.8.5",
 		"preact": "^10.24.3",
-		"rolldown": "link:../../../others/rolldown/packages/rolldown",
+		"rolldown": "0.14.0-snapshot-12d7e71-20241201004055",
 		"typescript": "^5.6.3",
 		"vite": "6.0.0-beta.8"
 	},

--- a/viteroll/pnpm-lock.yaml
+++ b/viteroll/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  rolldown: 0.13.2-snapshot-a292401-20241105072341
+  rolldown: file:./rolldown-0.14.0.tgz
   vite: 6.0.0-beta.8
 
 importers:
@@ -35,8 +35,8 @@ importers:
         specifier: ^10.24.3
         version: 10.24.3
       rolldown:
-        specifier: 0.13.2-snapshot-a292401-20241105072341
-        version: 0.13.2-snapshot-a292401-20241105072341
+        specifier: file:rolldown-0.14.0.tgz
+        version: file:rolldown-0.14.0.tgz
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -376,63 +376,63 @@ packages:
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
 
-  '@rolldown/binding-darwin-arm64@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-IvGCR1JGF55EM8t1HYgNyF7RNpf/lC5++WAWPmsdWcM6aDnc2ayWLVeEq/F5UCxJGGBnXDsPH8+FBMxBf/Ieag==}
+  '@rolldown/binding-darwin-arm64@0.14.0':
+    resolution: {integrity: sha512-0GneNB1lW+k6VyBeKZAAyjoJ27r+gCDV+xI56aifQteaHAhFb0q8etJE5KpOOt65Hz0xXVjENilDKS+ibn1lcA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-OUbQy963o7pCdy1KnumyJUDY86dBQSdiektSpsOZOgyEB7tMTsd69EOAbqqyrxz2euQgDVveGJyD1GDgw2/ypg==}
+  '@rolldown/binding-darwin-x64@0.14.0':
+    resolution: {integrity: sha512-MG+pbDhufD2Fkua7J32XAkK6OoHzS/P1KFwDv+J7YvD6KZ/vEz8GklXtM4Woby+rbvbNmgoT4MV1BtHENONr3A==}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-KWvitRouQ2J9ZRd+ioaJ4Aa+iXjqh8Ugf90RfwsSHTgX5P3b75lJbw19ObH4cranWAHyu1Z3Oz3m8Q5TfTIqpw==}
+  '@rolldown/binding-freebsd-x64@0.14.0':
+    resolution: {integrity: sha512-ojbJdM8f6+099WfFL/ggQ0F5o2/lHypQBj7WgIPL2Iqr3KleRVN57YTZPu0SJ/bK0OWrx2ZaWBLb6WpDsIx2zg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-fPgIOpmARKshz/ZWzTkfX/a1tUbU+3gedEUA9+Ry2d0yeKF8unnEvpvfw8FRh0Ht2Uq8X+cs54ZpQS37nlimfA==}
+  '@rolldown/binding-linux-arm-gnueabihf@0.14.0':
+    resolution: {integrity: sha512-cI8UBQDS6xFWg6Pe5gPXZYXskt2BQ4nVEoGGaHZsav8PWC31cEZhSkUj814anbmGoi7wl23/T2gNuCNysdWHxg==}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-oTgB9dXnFNNC1qxzbYwHLfnRViBxsQt7pPdCdpmbxZdcsQBQpSyqvf8IFU6VJn3GnBtJU0ysQ1s3BQ5TSSeNVQ==}
+  '@rolldown/binding-linux-arm64-gnu@0.14.0':
+    resolution: {integrity: sha512-vA2ewz6nun7mkW4lMwO3TzCuUi3mpcAo3xXhAwmIPT6yz7+ofJGLkq3N7oYfJQhH9ktHSEPA8JzPHvZ1ozAfgA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-musl@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-Q/F+iS43K6KXEB3LXwHoqxDbpude+vhC0P6Qp6HLctIksJf/2QreGTQ+aB0QVRwws2007MKJ4kYFi9ZpkfjG5A==}
+  '@rolldown/binding-linux-arm64-musl@0.14.0':
+    resolution: {integrity: sha512-uEoG+tzi0JqCVhuWmaOLR7hjuyDQ+a9OudYDeArkeAD2tY8fNyd9gAOfjzyYhgBcYvOLCo+4w2C3GnoSKy88FA==}
     cpu: [arm64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-gnu@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-SFSK2LkhuRJ6YDUHuSapZcuf7cp0tyQoO+1F3B+5Obu0s5CHv6HkkyJ/96GBvGCGEVXdtUNPKam32U+5Af4A9g==}
+  '@rolldown/binding-linux-x64-gnu@0.14.0':
+    resolution: {integrity: sha512-WSeo4JfiXCTRJDT5VG5Ohp3nhZittMrRA42wZjcHRajsuG7YsikmkSbTI88TXVjMSdXJBQK1zsBVOIpYfzKltQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-linux-x64-musl@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-OR6lEBRvFgXO2Zcr+WCWwhw9tl7S3ByVKBTEGV9ebeo0ScS4UtkChrsx13xJVOz5/o8dv0pYSV8c8OVatk/4jA==}
+  '@rolldown/binding-linux-x64-musl@0.14.0':
+    resolution: {integrity: sha512-gR9Xz+k2E5Xjd/6d+109Jpdwtaepa4Y0UvAA1hwMBM7LsDR0tMpryRYJlrKqaFvhFyzMfd45HunrX4dttQV5hQ==}
     cpu: [x64]
     os: [linux]
 
-  '@rolldown/binding-wasm32-wasi@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-OHewT4F6WjdFrbg56p/qByEU45ed5n+m4/NBHMwldQf7uxRS03urCI7WYRQcZe0H4Bl95cIQsPbjAQxBRzwlCw==}
+  '@rolldown/binding-wasm32-wasi@0.14.0':
+    resolution: {integrity: sha512-5tEWnRnWlxgn45Z/LGL0Ds/gZ/B8dY84PfKNq6S1elweLGgjlhDSRbNaZiX/umvELa9e1dbYNPCFZiEhHSUvkQ==}
     engines: {node: '>=14.21.3'}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-C09eFp4vjwzbfTwRBgScLIMNcey8dT1evcgb7dllkaurSONMRPweUrA8w+AjLoNLxmYtjo/8UXzy/WNAA9/9GA==}
+  '@rolldown/binding-win32-arm64-msvc@0.14.0':
+    resolution: {integrity: sha512-VIdWQkE0vvaORRy0NXW+z+IuqTZ96/FbVKVFKlsOMcrhBOibzvy8LobKaxUIOPJ/WzPEyrmhnMRHJpWbtaPJmw==}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-ia32-msvc@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-nm9AH+s4LN/gUb2jNdr1E1nUCMFs/Cz2wcRn492LQHahDVBALDaY/VZGftqSp339tsMjaEZea+FzxmlTECGxCQ==}
+  '@rolldown/binding-win32-ia32-msvc@0.14.0':
+    resolution: {integrity: sha512-0nOHZhjcX93FiY6SLk0iMTqFf3wzRXYsneGstfIlkob8tEncukMdS+iv9JfG9k15e5fRYcwfHu8wW55qmLYj/w==}
     cpu: [ia32]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@0.13.2-snapshot-a292401-20241105072341':
-    resolution: {integrity: sha512-2YEn48I1RlOR4ATbVNqCjGvTPUbKbeUhtLT/+l++pJ5o6LwO3/RZMEB6J5mN5ZXQ2mXqpmbBOR06fY8tFThLSw==}
+  '@rolldown/binding-win32-x64-msvc@0.14.0':
+    resolution: {integrity: sha512-RKNpJKIG5J6dgR/0IpxHmZkYYnHJE8vDm3qL8Zq9EY7kxOsCNZbrj5leU7qbibqfHHR+9Ij4vhTL1YuLz/ch5Q==}
     cpu: [x64]
     os: [win32]
 
@@ -721,9 +721,15 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  rolldown@0.13.2-snapshot-a292401-20241105072341:
-    resolution: {integrity: sha512-WA2U4g9E+d/J1u/nAldwnxmE7KOOGxdnjg6GX/qsPekVqQ0e+dPV7qrGYWIBj3twjPFxdp+9bzsXrFW3LUhakQ==}
+  rolldown@file:rolldown-0.14.0.tgz:
+    resolution: {integrity: sha512-Q10owNKABGy+uo/Dl/OI3xTLX5ZpqKOOBeeVTgnu5xfZF0o/FgLGqzSsbcnuwZzXaO1ZgBg7qqxcX9227jG38w==, tarball: file:rolldown-0.14.0.tgz}
+    version: 0.14.0
     hasBin: true
+    peerDependencies:
+      '@babel/runtime': '>=7'
+    peerDependenciesMeta:
+      '@babel/runtime':
+        optional: true
 
   rollup@4.24.3:
     resolution: {integrity: sha512-HBW896xR5HGmoksbi3JBDtmVzWiPAYqp7wip50hjQ67JbDz61nyoMPdqu1DvVW9asYb2M65Z20ZHsyJCMqMyDg==}
@@ -1027,42 +1033,42 @@ snapshots:
 
   '@polka/url@1.0.0-next.28': {}
 
-  '@rolldown/binding-darwin-arm64@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-darwin-arm64@0.14.0':
     optional: true
 
-  '@rolldown/binding-darwin-x64@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-darwin-x64@0.14.0':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-freebsd-x64@0.14.0':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-linux-arm-gnueabihf@0.14.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-linux-arm64-gnu@0.14.0':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-linux-arm64-musl@0.14.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-linux-x64-gnu@0.14.0':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-linux-x64-musl@0.14.0':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-wasm32-wasi@0.14.0':
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.5
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-win32-arm64-msvc@0.14.0':
     optional: true
 
-  '@rolldown/binding-win32-ia32-msvc@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-win32-ia32-msvc@0.14.0':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@0.13.2-snapshot-a292401-20241105072341':
+  '@rolldown/binding-win32-x64-msvc@0.14.0':
     optional: true
 
   '@rollup/rollup-android-arm-eabi@4.24.3':
@@ -1323,7 +1329,7 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
-  rolldown@0.13.2-snapshot-a292401-20241105072341:
+  rolldown@file:rolldown-0.14.0.tgz:
     dependencies:
       '@parcel/watcher': 2.4.1
       chokidar: 3.6.0
@@ -1332,18 +1338,18 @@ snapshots:
       ws: 8.18.0
       zod: 3.23.8
     optionalDependencies:
-      '@rolldown/binding-darwin-arm64': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-darwin-x64': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-freebsd-x64': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-linux-arm-gnueabihf': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-linux-arm64-gnu': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-linux-arm64-musl': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-linux-x64-gnu': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-linux-x64-musl': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-wasm32-wasi': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-win32-arm64-msvc': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-win32-ia32-msvc': 0.13.2-snapshot-a292401-20241105072341
-      '@rolldown/binding-win32-x64-msvc': 0.13.2-snapshot-a292401-20241105072341
+      '@rolldown/binding-darwin-arm64': 0.14.0
+      '@rolldown/binding-darwin-x64': 0.14.0
+      '@rolldown/binding-freebsd-x64': 0.14.0
+      '@rolldown/binding-linux-arm-gnueabihf': 0.14.0
+      '@rolldown/binding-linux-arm64-gnu': 0.14.0
+      '@rolldown/binding-linux-arm64-musl': 0.14.0
+      '@rolldown/binding-linux-x64-gnu': 0.14.0
+      '@rolldown/binding-linux-x64-musl': 0.14.0
+      '@rolldown/binding-wasm32-wasi': 0.14.0
+      '@rolldown/binding-win32-arm64-msvc': 0.14.0
+      '@rolldown/binding-win32-ia32-msvc': 0.14.0
+      '@rolldown/binding-win32-x64-msvc': 0.14.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color

--- a/viteroll/pnpm-lock.yaml
+++ b/viteroll/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  rolldown: file:./rolldown-0.14.0.tgz
+  rolldown: link:../../../others/rolldown/packages/rolldown
   vite: 6.0.0-beta.8
 
 importers:
@@ -35,8 +35,8 @@ importers:
         specifier: ^10.24.3
         version: 10.24.3
       rolldown:
-        specifier: file:rolldown-0.14.0.tgz
-        version: file:rolldown-0.14.0.tgz
+        specifier: link:../../../others/rolldown/packages/rolldown
+        version: link:../../../others/rolldown/packages/rolldown
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -132,15 +132,6 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
-
-  '@emnapi/core@1.3.1':
-    resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
-
-  '@emnapi/runtime@1.3.1':
-    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
-
-  '@emnapi/wasi-threads@1.0.1':
-    resolution: {integrity: sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==}
 
   '@esbuild/aix-ppc64@0.24.0':
     resolution: {integrity: sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==}
@@ -289,85 +280,6 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
-  '@napi-rs/wasm-runtime@0.2.5':
-    resolution: {integrity: sha512-kwUxR7J9WLutBbulqg1dfOrMTwhMdXLdcGUhcbCcGwnPLt3gz19uHVdwH1syKVDbE022ZS2vZxOWflFLS0YTjw==}
-
-  '@parcel/watcher-android-arm64@2.4.1':
-    resolution: {integrity: sha512-LOi/WTbbh3aTn2RYddrO8pnapixAziFl6SMxHM69r3tvdSm94JtCenaKgk1GRg5FJ5wpMCpHeW+7yqPlvZv7kg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [android]
-
-  '@parcel/watcher-darwin-arm64@2.4.1':
-    resolution: {integrity: sha512-ln41eihm5YXIY043vBrrHfn94SIBlqOWmoROhsMVTSXGh0QahKGy77tfEywQ7v3NywyxBBkGIfrWRHm0hsKtzA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@parcel/watcher-darwin-x64@2.4.1':
-    resolution: {integrity: sha512-yrw81BRLjjtHyDu7J61oPuSoeYWR3lDElcPGJyOvIXmor6DEo7/G2u1o7I38cwlcoBHQFULqF6nesIX3tsEXMg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@parcel/watcher-freebsd-x64@2.4.1':
-    resolution: {integrity: sha512-TJa3Pex/gX3CWIx/Co8k+ykNdDCLx+TuZj3f3h7eOjgpdKM+Mnix37RYsYU4LHhiYJz3DK5nFCCra81p6g050w==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@parcel/watcher-linux-arm-glibc@2.4.1':
-    resolution: {integrity: sha512-4rVYDlsMEYfa537BRXxJ5UF4ddNwnr2/1O4MHM5PjI9cvV2qymvhwZSFgXqbS8YoTk5i/JR0L0JDs69BUn45YA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm]
-    os: [linux]
-
-  '@parcel/watcher-linux-arm64-glibc@2.4.1':
-    resolution: {integrity: sha512-BJ7mH985OADVLpbrzCLgrJ3TOpiZggE9FMblfO65PlOCdG++xJpKUJ0Aol74ZUIYfb8WsRlUdgrZxKkz3zXWYA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@parcel/watcher-linux-arm64-musl@2.4.1':
-    resolution: {integrity: sha512-p4Xb7JGq3MLgAfYhslU2SjoV9G0kI0Xry0kuxeG/41UfpjHGOhv7UoUDAz/jb1u2elbhazy4rRBL8PegPJFBhA==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@parcel/watcher-linux-x64-glibc@2.4.1':
-    resolution: {integrity: sha512-s9O3fByZ/2pyYDPoLM6zt92yu6P4E39a03zvO0qCHOTjxmt3GHRMLuRZEWhWLASTMSrrnVNWdVI/+pUElJBBBg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@parcel/watcher-linux-x64-musl@2.4.1':
-    resolution: {integrity: sha512-L2nZTYR1myLNST0O632g0Dx9LyMNHrn6TOt76sYxWLdff3cB22/GZX2UPtJnaqQPdCRoszoY5rcOj4oMTtp5fQ==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [linux]
-
-  '@parcel/watcher-win32-arm64@2.4.1':
-    resolution: {integrity: sha512-Uq2BPp5GWhrq/lcuItCHoqxjULU1QYEcyjSO5jqqOK8RNFDBQnenMMx4gAl3v8GiWa59E9+uDM7yZ6LxwUIfRg==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@parcel/watcher-win32-ia32@2.4.1':
-    resolution: {integrity: sha512-maNRit5QQV2kgHFSYwftmPBxiuK5u4DXjbXx7q6eKjq5dsLXZ4FJiVvlcw35QXzk0KrUecJmuVFbj4uV9oYrcw==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [ia32]
-    os: [win32]
-
-  '@parcel/watcher-win32-x64@2.4.1':
-    resolution: {integrity: sha512-+DvS92F9ezicfswqrvIRM2njcYJbd5mb9CUgtrHCHmvn7pPPa+nMDRu1o1bYYz/l5IB2NVGNJWiH7h1E58IF2A==}
-    engines: {node: '>= 10.0.0'}
-    cpu: [x64]
-    os: [win32]
-
-  '@parcel/watcher@2.4.1':
-    resolution: {integrity: sha512-HNjmfLQEVRZmHRET336f20H/8kOozUGwk7yajvsonjNxbj2wBTK1WsQuHkD5yYh9RxFGL2EyDHryOihOwUoKDA==}
-    engines: {node: '>= 10.0.0'}
-
   '@playwright/test@1.48.2':
     resolution: {integrity: sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==}
     engines: {node: '>=18'}
@@ -375,66 +287,6 @@ packages:
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
-
-  '@rolldown/binding-darwin-arm64@0.14.0':
-    resolution: {integrity: sha512-0GneNB1lW+k6VyBeKZAAyjoJ27r+gCDV+xI56aifQteaHAhFb0q8etJE5KpOOt65Hz0xXVjENilDKS+ibn1lcA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@0.14.0':
-    resolution: {integrity: sha512-MG+pbDhufD2Fkua7J32XAkK6OoHzS/P1KFwDv+J7YvD6KZ/vEz8GklXtM4Woby+rbvbNmgoT4MV1BtHENONr3A==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rolldown/binding-freebsd-x64@0.14.0':
-    resolution: {integrity: sha512-ojbJdM8f6+099WfFL/ggQ0F5o2/lHypQBj7WgIPL2Iqr3KleRVN57YTZPu0SJ/bK0OWrx2ZaWBLb6WpDsIx2zg==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@rolldown/binding-linux-arm-gnueabihf@0.14.0':
-    resolution: {integrity: sha512-cI8UBQDS6xFWg6Pe5gPXZYXskt2BQ4nVEoGGaHZsav8PWC31cEZhSkUj814anbmGoi7wl23/T2gNuCNysdWHxg==}
-    cpu: [arm]
-    os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@0.14.0':
-    resolution: {integrity: sha512-vA2ewz6nun7mkW4lMwO3TzCuUi3mpcAo3xXhAwmIPT6yz7+ofJGLkq3N7oYfJQhH9ktHSEPA8JzPHvZ1ozAfgA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rolldown/binding-linux-arm64-musl@0.14.0':
-    resolution: {integrity: sha512-uEoG+tzi0JqCVhuWmaOLR7hjuyDQ+a9OudYDeArkeAD2tY8fNyd9gAOfjzyYhgBcYvOLCo+4w2C3GnoSKy88FA==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@rolldown/binding-linux-x64-gnu@0.14.0':
-    resolution: {integrity: sha512-WSeo4JfiXCTRJDT5VG5Ohp3nhZittMrRA42wZjcHRajsuG7YsikmkSbTI88TXVjMSdXJBQK1zsBVOIpYfzKltQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rolldown/binding-linux-x64-musl@0.14.0':
-    resolution: {integrity: sha512-gR9Xz+k2E5Xjd/6d+109Jpdwtaepa4Y0UvAA1hwMBM7LsDR0tMpryRYJlrKqaFvhFyzMfd45HunrX4dttQV5hQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@rolldown/binding-wasm32-wasi@0.14.0':
-    resolution: {integrity: sha512-5tEWnRnWlxgn45Z/LGL0Ds/gZ/B8dY84PfKNq6S1elweLGgjlhDSRbNaZiX/umvELa9e1dbYNPCFZiEhHSUvkQ==}
-    engines: {node: '>=14.21.3'}
-    cpu: [wasm32]
-
-  '@rolldown/binding-win32-arm64-msvc@0.14.0':
-    resolution: {integrity: sha512-VIdWQkE0vvaORRy0NXW+z+IuqTZ96/FbVKVFKlsOMcrhBOibzvy8LobKaxUIOPJ/WzPEyrmhnMRHJpWbtaPJmw==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-ia32-msvc@0.14.0':
-    resolution: {integrity: sha512-0nOHZhjcX93FiY6SLk0iMTqFf3wzRXYsneGstfIlkob8tEncukMdS+iv9JfG9k15e5fRYcwfHu8wW55qmLYj/w==}
-    cpu: [ia32]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@0.14.0':
-    resolution: {integrity: sha512-RKNpJKIG5J6dgR/0IpxHmZkYYnHJE8vDm3qL8Zq9EY7kxOsCNZbrj5leU7qbibqfHHR+9Ij4vhTL1YuLz/ch5Q==}
-    cpu: [x64]
-    os: [win32]
 
   '@rollup/rollup-android-arm-eabi@4.24.3':
     resolution: {integrity: sha512-ufb2CH2KfBWPJok95frEZZ82LtDl0A6QKTa8MoM+cWwDZvVGl5/jNb79pIhRvAalUu+7LD91VYR0nwRD799HkQ==}
@@ -526,9 +378,6 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@tybys/wasm-util@0.9.0':
-    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
-
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -544,64 +393,13 @@ packages:
   '@types/react@18.3.12':
     resolution: {integrity: sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==}
 
-  anymatch@3.1.3:
-    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
-    engines: {node: '>= 8'}
-
-  binary-extensions@2.3.0:
-    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
-    engines: {node: '>=8'}
-
-  braces@3.0.3:
-    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
-    engines: {node: '>=8'}
-
-  chokidar@3.6.0:
-    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
-    engines: {node: '>= 8.10.0'}
-
-  connect@3.7.0:
-    resolution: {integrity: sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==}
-    engines: {node: '>= 0.10.0'}
-
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
-
-  debug@2.6.9:
-    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
-    peerDependencies:
-      supports-color: '*'
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-
-  detect-libc@1.0.3:
-    resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
-    engines: {node: '>=0.10'}
-    hasBin: true
-
-  ee-first@1.1.1:
-    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-
-  encodeurl@1.0.2:
-    resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
-    engines: {node: '>= 0.8'}
 
   esbuild@0.24.0:
     resolution: {integrity: sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==}
     engines: {node: '>=18'}
     hasBin: true
-
-  escape-html@1.0.3:
-    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-
-  fill-range@7.1.1:
-    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
-    engines: {node: '>=8'}
-
-  finalhandler@1.1.2:
-    resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
-    engines: {node: '>= 0.8'}
 
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
@@ -613,32 +411,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
-  graceful-fs@4.2.11:
-    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
-
-  is-binary-path@2.1.0:
-    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
-    engines: {node: '>=8'}
-
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
-
-  is-number@7.0.0:
-    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
-    engines: {node: '>=0.12.0'}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -649,43 +421,17 @@ packages:
   magic-string@0.30.12:
     resolution: {integrity: sha512-Ea8I3sQMVXr8JhN4z+H/d8zwo+tYDgHE9+5G4Wnrwhs0gaK9fXTKx0Tw5Xwsd/bCPTTZNRAdpyzvoeORe9LYpw==}
 
-  micromatch@4.0.8:
-    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
-    engines: {node: '>=8.6'}
-
   mrmime@2.0.0:
     resolution: {integrity: sha512-eu38+hdgojoyq63s+yTpN4XMBdt5l8HhMhc4VKLO9KM5caLIBvUm4thi7fFaxyTmCKeNnXZ5pAlBwCUnhA09uw==}
     engines: {node: '>=10'}
-
-  ms@2.0.0:
-    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   nanoid@3.3.7:
     resolution: {integrity: sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  node-addon-api@7.1.1:
-    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
-
-  normalize-path@3.0.0:
-    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
-  on-finished@2.3.0:
-    resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
-    engines: {node: '>= 0.8'}
-
-  parseurl@1.3.3:
-    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
-    engines: {node: '>= 0.8'}
-
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
 
   playwright-core@1.48.2:
     resolution: {integrity: sha512-sjjw+qrLFlriJo64du+EK0kJgZzoQPsabGF4lBvsid+3CNIZIYLgnMj9V6JY5VhM2Peh20DJWIVpVljLLnlawA==}
@@ -717,20 +463,6 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
-  readdirp@3.6.0:
-    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
-    engines: {node: '>=8.10.0'}
-
-  rolldown@file:rolldown-0.14.0.tgz:
-    resolution: {integrity: sha512-Q10owNKABGy+uo/Dl/OI3xTLX5ZpqKOOBeeVTgnu5xfZF0o/FgLGqzSsbcnuwZzXaO1ZgBg7qqxcX9227jG38w==, tarball: file:rolldown-0.14.0.tgz}
-    version: 0.14.0
-    hasBin: true
-    peerDependencies:
-      '@babel/runtime': '>=7'
-    peerDependenciesMeta:
-      '@babel/runtime':
-        optional: true
-
   rollup@4.24.3:
     resolution: {integrity: sha512-HBW896xR5HGmoksbi3JBDtmVzWiPAYqp7wip50hjQ67JbDz61nyoMPdqu1DvVW9asYb2M65Z20ZHsyJCMqMyDg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -747,20 +479,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
-  statuses@1.5.0:
-    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
-    engines: {node: '>= 0.6'}
-
-  to-regex-range@5.0.1:
-    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
-    engines: {node: '>=8.0'}
-
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
-
-  tslib@2.8.0:
-    resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
 
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
@@ -769,14 +490,6 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-
-  unpipe@1.0.0:
-    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
-    engines: {node: '>= 0.8'}
-
-  utils-merge@1.0.1:
-    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
-    engines: {node: '>= 0.4.0'}
 
   vite@6.0.0-beta.8:
     resolution: {integrity: sha512-KbUpk2e8NvL1aYGJdV4FfppDq/ygwTm+YUqGyUUb30K9R2Z9Up6a1D4203D2YRQb5pT4hChmYsXPA3MZ1R3ohA==}
@@ -818,25 +531,6 @@ packages:
       yaml:
         optional: true
 
-  watchpack@2.4.2:
-    resolution: {integrity: sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==}
-    engines: {node: '>=10.13.0'}
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  zod@3.23.8:
-    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
-
 snapshots:
 
   '@biomejs/biome@1.9.4':
@@ -872,22 +566,6 @@ snapshots:
     optional: true
 
   '@biomejs/cli-win32-x64@1.9.4':
-    optional: true
-
-  '@emnapi/core@1.3.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.0.1
-      tslib: 2.8.0
-    optional: true
-
-  '@emnapi/runtime@1.3.1':
-    dependencies:
-      tslib: 2.8.0
-    optional: true
-
-  '@emnapi/wasi-threads@1.0.1':
-    dependencies:
-      tslib: 2.8.0
     optional: true
 
   '@esbuild/aix-ppc64@0.24.0':
@@ -964,112 +642,11 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
-  '@napi-rs/wasm-runtime@0.2.5':
-    dependencies:
-      '@emnapi/core': 1.3.1
-      '@emnapi/runtime': 1.3.1
-      '@tybys/wasm-util': 0.9.0
-    optional: true
-
-  '@parcel/watcher-android-arm64@2.4.1':
-    optional: true
-
-  '@parcel/watcher-darwin-arm64@2.4.1':
-    optional: true
-
-  '@parcel/watcher-darwin-x64@2.4.1':
-    optional: true
-
-  '@parcel/watcher-freebsd-x64@2.4.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm-glibc@2.4.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm64-glibc@2.4.1':
-    optional: true
-
-  '@parcel/watcher-linux-arm64-musl@2.4.1':
-    optional: true
-
-  '@parcel/watcher-linux-x64-glibc@2.4.1':
-    optional: true
-
-  '@parcel/watcher-linux-x64-musl@2.4.1':
-    optional: true
-
-  '@parcel/watcher-win32-arm64@2.4.1':
-    optional: true
-
-  '@parcel/watcher-win32-ia32@2.4.1':
-    optional: true
-
-  '@parcel/watcher-win32-x64@2.4.1':
-    optional: true
-
-  '@parcel/watcher@2.4.1':
-    dependencies:
-      detect-libc: 1.0.3
-      is-glob: 4.0.3
-      micromatch: 4.0.8
-      node-addon-api: 7.1.1
-    optionalDependencies:
-      '@parcel/watcher-android-arm64': 2.4.1
-      '@parcel/watcher-darwin-arm64': 2.4.1
-      '@parcel/watcher-darwin-x64': 2.4.1
-      '@parcel/watcher-freebsd-x64': 2.4.1
-      '@parcel/watcher-linux-arm-glibc': 2.4.1
-      '@parcel/watcher-linux-arm64-glibc': 2.4.1
-      '@parcel/watcher-linux-arm64-musl': 2.4.1
-      '@parcel/watcher-linux-x64-glibc': 2.4.1
-      '@parcel/watcher-linux-x64-musl': 2.4.1
-      '@parcel/watcher-win32-arm64': 2.4.1
-      '@parcel/watcher-win32-ia32': 2.4.1
-      '@parcel/watcher-win32-x64': 2.4.1
-
   '@playwright/test@1.48.2':
     dependencies:
       playwright: 1.48.2
 
   '@polka/url@1.0.0-next.28': {}
-
-  '@rolldown/binding-darwin-arm64@0.14.0':
-    optional: true
-
-  '@rolldown/binding-darwin-x64@0.14.0':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@0.14.0':
-    optional: true
-
-  '@rolldown/binding-linux-arm-gnueabihf@0.14.0':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@0.14.0':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-musl@0.14.0':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@0.14.0':
-    optional: true
-
-  '@rolldown/binding-linux-x64-musl@0.14.0':
-    optional: true
-
-  '@rolldown/binding-wasm32-wasi@0.14.0':
-    dependencies:
-      '@napi-rs/wasm-runtime': 0.2.5
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@0.14.0':
-    optional: true
-
-  '@rolldown/binding-win32-ia32-msvc@0.14.0':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@0.14.0':
-    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.24.3':
     optional: true
@@ -1125,11 +702,6 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.24.3':
     optional: true
 
-  '@tybys/wasm-util@0.9.0':
-    dependencies:
-      tslib: 2.8.0
-    optional: true
-
   '@types/estree@1.0.6': {}
 
   '@types/node@22.8.5':
@@ -1147,49 +719,7 @@ snapshots:
       '@types/prop-types': 15.7.13
       csstype: 3.1.3
 
-  anymatch@3.1.3:
-    dependencies:
-      normalize-path: 3.0.0
-      picomatch: 2.3.1
-
-  binary-extensions@2.3.0: {}
-
-  braces@3.0.3:
-    dependencies:
-      fill-range: 7.1.1
-
-  chokidar@3.6.0:
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.3
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.3
-      normalize-path: 3.0.0
-      readdirp: 3.6.0
-    optionalDependencies:
-      fsevents: 2.3.3
-
-  connect@3.7.0:
-    dependencies:
-      debug: 2.6.9
-      finalhandler: 1.1.2
-      parseurl: 1.3.3
-      utils-merge: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   csstype@3.1.3: {}
-
-  debug@2.6.9:
-    dependencies:
-      ms: 2.0.0
-
-  detect-libc@1.0.3: {}
-
-  ee-first@1.1.1: {}
-
-  encodeurl@1.0.2: {}
 
   esbuild@0.24.0:
     optionalDependencies:
@@ -1218,49 +748,11 @@ snapshots:
       '@esbuild/win32-ia32': 0.24.0
       '@esbuild/win32-x64': 0.24.0
 
-  escape-html@1.0.3: {}
-
-  fill-range@7.1.1:
-    dependencies:
-      to-regex-range: 5.0.1
-
-  finalhandler@1.1.2:
-    dependencies:
-      debug: 2.6.9
-      encodeurl: 1.0.2
-      escape-html: 1.0.3
-      on-finished: 2.3.0
-      parseurl: 1.3.3
-      statuses: 1.5.0
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-
   fsevents@2.3.2:
     optional: true
 
   fsevents@2.3.3:
     optional: true
-
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
-  glob-to-regexp@0.4.1: {}
-
-  graceful-fs@4.2.11: {}
-
-  is-binary-path@2.1.0:
-    dependencies:
-      binary-extensions: 2.3.0
-
-  is-extglob@2.1.1: {}
-
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
-
-  is-number@7.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -1272,30 +764,11 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  micromatch@4.0.8:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.1
-
   mrmime@2.0.0: {}
-
-  ms@2.0.0: {}
 
   nanoid@3.3.7: {}
 
-  node-addon-api@7.1.1: {}
-
-  normalize-path@3.0.0: {}
-
-  on-finished@2.3.0:
-    dependencies:
-      ee-first: 1.1.1
-
-  parseurl@1.3.3: {}
-
   picocolors@1.1.1: {}
-
-  picomatch@2.3.1: {}
 
   playwright-core@1.48.2: {}
 
@@ -1324,36 +797,6 @@ snapshots:
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  readdirp@3.6.0:
-    dependencies:
-      picomatch: 2.3.1
-
-  rolldown@file:rolldown-0.14.0.tgz:
-    dependencies:
-      '@parcel/watcher': 2.4.1
-      chokidar: 3.6.0
-      connect: 3.7.0
-      watchpack: 2.4.2
-      ws: 8.18.0
-      zod: 3.23.8
-    optionalDependencies:
-      '@rolldown/binding-darwin-arm64': 0.14.0
-      '@rolldown/binding-darwin-x64': 0.14.0
-      '@rolldown/binding-freebsd-x64': 0.14.0
-      '@rolldown/binding-linux-arm-gnueabihf': 0.14.0
-      '@rolldown/binding-linux-arm64-gnu': 0.14.0
-      '@rolldown/binding-linux-arm64-musl': 0.14.0
-      '@rolldown/binding-linux-x64-gnu': 0.14.0
-      '@rolldown/binding-linux-x64-musl': 0.14.0
-      '@rolldown/binding-wasm32-wasi': 0.14.0
-      '@rolldown/binding-win32-arm64-msvc': 0.14.0
-      '@rolldown/binding-win32-ia32-msvc': 0.14.0
-      '@rolldown/binding-win32-x64-msvc': 0.14.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
 
   rollup@4.24.3:
     dependencies:
@@ -1391,24 +834,11 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
-  statuses@1.5.0: {}
-
-  to-regex-range@5.0.1:
-    dependencies:
-      is-number: 7.0.0
-
   totalist@3.0.1: {}
-
-  tslib@2.8.0:
-    optional: true
 
   typescript@5.6.3: {}
 
   undici-types@6.19.8: {}
-
-  unpipe@1.0.0: {}
-
-  utils-merge@1.0.1: {}
 
   vite@6.0.0-beta.8(@types/node@22.8.5):
     dependencies:
@@ -1417,12 +847,3 @@ snapshots:
       rollup: 4.24.3
     optionalDependencies:
       '@types/node': 22.8.5
-
-  watchpack@2.4.2:
-    dependencies:
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-
-  ws@8.18.0: {}
-
-  zod@3.23.8: {}

--- a/viteroll/pnpm-lock.yaml
+++ b/viteroll/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  rolldown: link:../../../others/rolldown/packages/rolldown
+  rolldown: 0.14.0-snapshot-12d7e71-20241201004055
   vite: 6.0.0-beta.8
 
 importers:
@@ -35,8 +35,8 @@ importers:
         specifier: ^10.24.3
         version: 10.24.3
       rolldown:
-        specifier: link:../../../others/rolldown/packages/rolldown
-        version: link:../../../others/rolldown/packages/rolldown
+        specifier: 0.14.0-snapshot-12d7e71-20241201004055
+        version: 0.14.0-snapshot-12d7e71-20241201004055
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -132,6 +132,15 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@emnapi/core@1.3.1':
+    resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
+
+  '@emnapi/runtime@1.3.1':
+    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
+
+  '@emnapi/wasi-threads@1.0.1':
+    resolution: {integrity: sha512-iIBu7mwkq4UQGeMEM8bLwNK962nXdhodeScX4slfQnRhEMMzvYivHhutCIk8uojvmASXXPC2WNEjwxFWk72Oqw==}
 
   '@esbuild/aix-ppc64@0.24.0':
     resolution: {integrity: sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==}
@@ -280,6 +289,9 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
+  '@napi-rs/wasm-runtime@0.2.5':
+    resolution: {integrity: sha512-kwUxR7J9WLutBbulqg1dfOrMTwhMdXLdcGUhcbCcGwnPLt3gz19uHVdwH1syKVDbE022ZS2vZxOWflFLS0YTjw==}
+
   '@playwright/test@1.48.2':
     resolution: {integrity: sha512-54w1xCWfXuax7dz4W2M9uw0gDyh+ti/0K/MxcCUxChFh37kkdxPdfZDw5QBbuPUJHr1CiHJ1hXgSs+GgeQc5Zw==}
     engines: {node: '>=18'}
@@ -287,6 +299,66 @@ packages:
 
   '@polka/url@1.0.0-next.28':
     resolution: {integrity: sha512-8LduaNlMZGwdZ6qWrKlfa+2M4gahzFkprZiAt2TF8uS0qQgBizKXpXURqvTJ4WtmupWxaLqjRb2UCTe72mu+Aw==}
+
+  '@rolldown/binding-darwin-arm64@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-VnPsjtoJQaJlfFof/CW1Kh3miEtDkLi0J/IShaIhPrsmL4ZEcrITTp7/VThwlUsZpt/TvBx/VPmGPFQwe/xmQg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-K+b/a8cyrdDQ0H+wWgrgquHSQJ8l1EK/D0rbxv5mtdl8wUXQSP5CQwHSyNAvve2/zNDFLz4g/RGaqvaFVRtE+Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-x01+jgHEcjBT50R0msJeDkIaYBaCWJAhpzhcNip79H+soF4zOaaKt/PgyVSC4N97gewdzClgmgUEHV3dfR0z/Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-XwIgcHbrSdYg9okIYTznIS0dg0gNW76Wv6/Xt4gd2iSpwCk3RdAPJDDef4O2BtcSlk1sN+y5pHKlDXFFmME+WA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-AjU33kl38sca9gT9kfYI9nS8udOSIWK15bNdvZF7UZhNmBr2uB0KH3Fcib/HWafyEnL9XJ3pE48URAndJC+2WA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-l8ZaLq5WQmQOz75iSC+8AcUasouD3o8NR0jWqggXdrHZHJ3QylKVRIXQV5iJzdy4UzVZMh608UKt9kMH1N5R7A==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-6JAJ9mT93Am6jXbirKufpOb3f9RDXE/K4jSIHFqukKmBvI1wBiQUHYhs/dT9XB1NNsadP3LMxEX329FMn323hw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-sRaHk+a01vpxSUjxWioDmasDerR9lNTBQuoFuax+NY8z8lx2fiCwzoBoPm6a0zJHQa5ZuNvG6csLulfzg1F6JA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-wasm32-wasi@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-Itq/iYzbdoZdMh7qEGRD6Fw+IFOm3c18OzULjLNU0lD3mboEq3KF2YVthara0M92QRXes3rbGDjMTTb4w8AaMQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-1bKG8VlBmE93rdrfICtzjg/zdkkbMN/NM90pPGnmKnBegp/V1sJm4xm8QLkR+bUPN2JA8IwrtsOprE8J4vzf2g==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-BHe345BoHH4mbwL2OCrXyZxKqaZ6Y0qlwhrQU4daomgD8cEDBxZxwYAeFikzzS79yhoQ/s4EfhPN/ruZbsBsPw==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@0.14.0-snapshot-12d7e71-20241201004055':
+    resolution: {integrity: sha512-PA/cWPWeo9h9Pwc7qtKGcVqNj4khefmgyS5pWPcGqPkVn0msUzybq03KqkyRq18AkDsquZrYVrvUSQalUlm1mQ==}
+    cpu: [x64]
+    os: [win32]
 
   '@rollup/rollup-android-arm-eabi@4.24.3':
     resolution: {integrity: sha512-ufb2CH2KfBWPJok95frEZZ82LtDl0A6QKTa8MoM+cWwDZvVGl5/jNb79pIhRvAalUu+7LD91VYR0nwRD799HkQ==}
@@ -378,6 +450,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tybys/wasm-util@0.9.0':
+    resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
 
@@ -463,6 +538,15 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  rolldown@0.14.0-snapshot-12d7e71-20241201004055:
+    resolution: {integrity: sha512-p1F8yFTpVfNhczm/yGBIdDFZwJ0iX4jc1vG9dae761Zg5zh977RDj3+UIiPthsZSJ3NG/KdD88xNmBUUtyof0g==}
+    hasBin: true
+    peerDependencies:
+      '@babel/runtime': '>=7'
+    peerDependenciesMeta:
+      '@babel/runtime':
+        optional: true
+
   rollup@4.24.3:
     resolution: {integrity: sha512-HBW896xR5HGmoksbi3JBDtmVzWiPAYqp7wip50hjQ67JbDz61nyoMPdqu1DvVW9asYb2M65Z20ZHsyJCMqMyDg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -482,6 +566,9 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   typescript@5.6.3:
     resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
@@ -531,6 +618,9 @@ packages:
       yaml:
         optional: true
 
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
 snapshots:
 
   '@biomejs/biome@1.9.4':
@@ -566,6 +656,22 @@ snapshots:
     optional: true
 
   '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
+
+  '@emnapi/core@1.3.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.3.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.1':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
   '@esbuild/aix-ppc64@0.24.0':
@@ -642,11 +748,56 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
+  '@napi-rs/wasm-runtime@0.2.5':
+    dependencies:
+      '@emnapi/core': 1.3.1
+      '@emnapi/runtime': 1.3.1
+      '@tybys/wasm-util': 0.9.0
+    optional: true
+
   '@playwright/test@1.48.2':
     dependencies:
       playwright: 1.48.2
 
   '@polka/url@1.0.0-next.28': {}
+
+  '@rolldown/binding-darwin-arm64@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@0.14.0-snapshot-12d7e71-20241201004055':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.5
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@0.14.0-snapshot-12d7e71-20241201004055':
+    optional: true
 
   '@rollup/rollup-android-arm-eabi@4.24.3':
     optional: true
@@ -700,6 +851,11 @@ snapshots:
     optional: true
 
   '@rollup/rollup-win32-x64-msvc@4.24.3':
+    optional: true
+
+  '@tybys/wasm-util@0.9.0':
+    dependencies:
+      tslib: 2.8.1
     optional: true
 
   '@types/estree@1.0.6': {}
@@ -798,6 +954,23 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  rolldown@0.14.0-snapshot-12d7e71-20241201004055:
+    dependencies:
+      zod: 3.23.8
+    optionalDependencies:
+      '@rolldown/binding-darwin-arm64': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-darwin-x64': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-freebsd-x64': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-linux-arm-gnueabihf': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-linux-arm64-gnu': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-linux-arm64-musl': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-linux-x64-gnu': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-linux-x64-musl': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-wasm32-wasi': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-win32-arm64-msvc': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-win32-ia32-msvc': 0.14.0-snapshot-12d7e71-20241201004055
+      '@rolldown/binding-win32-x64-msvc': 0.14.0-snapshot-12d7e71-20241201004055
+
   rollup@4.24.3:
     dependencies:
       '@types/estree': 1.0.6
@@ -836,6 +1009,9 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tslib@2.8.1:
+    optional: true
+
   typescript@5.6.3: {}
 
   undici-types@6.19.8: {}
@@ -847,3 +1023,5 @@ snapshots:
       rollup: 4.24.3
     optionalDependencies:
       '@types/node': 22.8.5
+
+  zod@3.23.8: {}

--- a/viteroll/viteroll-runtime.js
+++ b/viteroll/viteroll-runtime.js
@@ -1,0 +1,237 @@
+// based on
+// https://github.com/rolldown/rolldown/blob/a29240168290e45b36fdc1a6d5c375281fb8dc3e/crates/rolldown/src/runtime/runtime-without-comments.js#L69
+// https://github.com/hi-ogawa/rolldown/blob/27d203a74d8dd95aed256bde29232d535bd294f4/crates/rolldown/src/runtime/runtime-app.js
+
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __esm = (fn, res) =>
+	function () {
+		return fn && (res = (0, fn[__getOwnPropNames(fn)[0]])((fn = 0))), res;
+	};
+var __esmMin = (fn, res) => () => (fn && (res = fn((fn = 0))), res);
+var __commonJS = (cb, mod) =>
+	function () {
+		return (
+			mod ||
+				(0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod),
+			mod.exports
+		);
+	};
+var __commonJSMin = (cb, mod) => () => (
+	mod || cb((mod = { exports: {} }).exports, mod), mod.exports
+);
+var __export = (target, all) => {
+	for (var name in all)
+		__defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+	if ((from && typeof from === "object") || typeof from === "function")
+		for (
+			var keys = __getOwnPropNames(from), i = 0, n = keys.length, key;
+			i < n;
+			i++
+		) {
+			key = keys[i];
+			if (!__hasOwnProp.call(to, key) && key !== except)
+				__defProp(to, key, {
+					get: ((k) => from[k]).bind(null, key),
+					enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable,
+				});
+		}
+	return to;
+};
+var __reExport = (target, mod, secondTarget) => (
+	__copyProps(target, mod, "default"),
+	secondTarget && __copyProps(secondTarget, mod, "default")
+);
+var __toESM = (mod, isNodeMode, target) => (
+	(target = mod != null ? __create(__getProtoOf(mod)) : {}),
+	__copyProps(
+		isNodeMode || !mod || !mod.__esModule
+			? __defProp(target, "default", { value: mod, enumerable: true })
+			: target,
+		mod,
+	)
+);
+var __toCommonJS = (mod) =>
+	__copyProps(__defProp({}, "__esModule", { value: true }), mod);
+var __toBinaryNode = (base64) => new Uint8Array(Buffer.from(base64, "base64"));
+var __toBinary = /* @__PURE__ */ (() => {
+	var table = new Uint8Array(128);
+	for (var i = 0; i < 64; i++)
+		table[i < 26 ? i + 65 : i < 52 ? i + 71 : i < 62 ? i - 4 : i * 4 - 205] = i;
+	return (base64) => {
+		var n = base64.length,
+			bytes = new Uint8Array(
+				(((n - (base64[n - 1] == "=") - (base64[n - 2] == "=")) * 3) / 4) | 0,
+			);
+		for (var i = 0, j = 0; i < n; ) {
+			var c0 = table[base64.charCodeAt(i++)],
+				c1 = table[base64.charCodeAt(i++)];
+			var c2 = table[base64.charCodeAt(i++)],
+				c3 = table[base64.charCodeAt(i++)];
+			bytes[j++] = (c0 << 2) | (c1 >> 4);
+			bytes[j++] = (c1 << 4) | (c2 >> 2);
+			bytes[j++] = (c2 << 6) | c3;
+		}
+		return bytes;
+	};
+})();
+
+var rolldown_runtime = (self.rolldown_runtime = {
+	patching: false,
+	patchedModuleFactoryMap: {},
+	executeModuleStack: [],
+	moduleCache: {},
+	moduleFactoryMap: {},
+	define: function (id, factory) {
+		if (self.patching) {
+			this.patchedModuleFactoryMap[id] = factory;
+		} else {
+			this.moduleFactoryMap[id] = factory;
+		}
+	},
+	require: function (id) {
+		const parent =
+			this.executeModuleStack.length >= 1
+				? this.executeModuleStack[this.executeModuleStack.length - 1]
+				: null;
+		if (this.moduleCache[id]) {
+			var module = this.moduleCache[id];
+			if (parent && module.parents.indexOf(parent) === -1) {
+				module.parents.push(parent);
+			}
+			return module.exports;
+		}
+		var factory = this.moduleFactoryMap[id];
+		if (!factory) {
+			throw new Error("Module not found: " + id);
+		}
+		var module = (this.moduleCache[id] = {
+			exports: {},
+			parents: parent ? [parent] : [],
+			hot: {
+				selfAccept: false,
+				acceptCallbacks: [],
+				accept: function (callback) {
+					this.selfAccept = true;
+					if (callback && typeof callback === "function") {
+						this.acceptCallbacks.push({
+							deps: [id],
+							callback,
+						});
+					}
+				},
+			},
+		});
+		this.executeModuleStack.push(id);
+		factory(this.require.bind(this), module, module.exports);
+		this.executeModuleStack.pop();
+		return module.exports;
+	},
+	patch: function (updateModuleIds, callback) {
+		self.patching = true;
+
+		callback();
+
+		var boundaries = [];
+		var invalidModuleIds = [];
+		var acceptCallbacks = [];
+
+		for (var i = 0; i < updateModuleIds.length; i++) {
+			foundBoundariesAndInvalidModuleIds(
+				updateModuleIds[i],
+				boundaries,
+				invalidModuleIds,
+				acceptCallbacks,
+			);
+		}
+
+		for (var i = 0; i < invalidModuleIds.length; i++) {
+			var id = invalidModuleIds[i];
+			delete this.moduleCache[id];
+		}
+
+		for (var id in this.patchedModuleFactoryMap) {
+			this.moduleFactoryMap[id] = this.patchedModuleFactoryMap[id];
+		}
+		this.patchedModuleFactoryMap = {};
+
+		for (var i = 0; i < boundaries.length; i++) {
+			this.require(boundaries[i]);
+		}
+
+		for (var i = 0; i < acceptCallbacks.length; i++) {
+			var item = acceptCallbacks[i];
+			item.callback.apply(
+				null,
+				item.deps.map((dep) => this.moduleCache[dep].exports),
+			);
+		}
+
+		self.patching = false;
+
+		function foundBoundariesAndInvalidModuleIds(
+			updateModuleId,
+			boundaries,
+			invalidModuleIds,
+			acceptCallbacks,
+		) {
+			var queue = [{ moduleId: updateModuleId, chain: [updateModuleId] }];
+			var visited = {};
+
+			while (queue.length > 0) {
+				var item = queue.pop();
+				var moduleId = item.moduleId;
+				var chain = item.chain;
+
+				if (visited[moduleId]) {
+					continue;
+				}
+
+				var module = rolldown_runtime.moduleCache[moduleId];
+				if (!module) {
+					continue;
+				}
+
+				if (module.hot.selfAccept) {
+					if (boundaries.indexOf(moduleId) === -1) {
+						boundaries.push(moduleId);
+
+						for (var i = 0; i < module.hot.acceptCallbacks.length; i++) {
+							var item = module.hot.acceptCallbacks[i];
+							acceptCallbacks.push(item);
+						}
+					}
+					for (var i = 0; i < chain.length; i++) {
+						if (invalidModuleIds.indexOf(chain[i]) === -1) {
+							invalidModuleIds.push(chain[i]);
+						}
+					}
+					continue;
+				}
+
+				boundaries.push(moduleId);
+				invalidModuleIds.push(moduleId);
+				if (module.parents.length === 0) {
+					globalThis.window?.location.reload();
+					break;
+				}
+
+				for (var i = 0; i < module.parents.length; i++) {
+					var parent = module.parents[i];
+					queue.push({
+						moduleId: parent,
+						chain: chain.concat([parent]),
+					});
+				}
+
+				visited[moduleId] = true;
+			}
+		}
+	},
+});

--- a/viteroll/viteroll.ts
+++ b/viteroll/viteroll.ts
@@ -348,7 +348,7 @@ ${innerCode}
 	}
 
 	async import(input: string): Promise<unknown> {
-		if (this.outputOptions.format === "app") {
+		if (this.outputOptions.format === "experimental-app") {
 			return this.getRunner().import(input);
 		}
 		// input is no use

--- a/viteroll/viteroll.ts
+++ b/viteroll/viteroll.ts
@@ -310,7 +310,10 @@ self.rolldown_runtime.patch(${JSON.stringify(stableIds)}, function(){
 ${innerCode}
 });
 `;
-		return [path.join(this.outDir, "hmr-update.js"), output];
+		// dump for debugging
+		const updatePath = path.join(this.outDir, `hmr-update-${Date.now()}.js`);
+		fs.writeFileSync(updatePath, output);
+		return [updatePath, output];
 	}
 
 	async handleUpdate(ctx: HmrContext) {
@@ -477,6 +480,10 @@ function viterollEntryPlugin(
 						"if (parent && module.parents.indexOf(parent) === -1) {",
 					)
 					.replace("if (item.deps.includes(updateModuleId)) {", "if (true) {")
+					.replace(
+						"var module = rolldown_runtime.moduleCache[moduleId];",
+						"var module = rolldown_runtime.moduleCache[moduleId]; if (!module) { continue; }",
+					)
 					.replace(
 						"for (var i = 0; i < module.parents.length; i++) {",
 						`

--- a/viteroll/viteroll.ts
+++ b/viteroll/viteroll.ts
@@ -476,6 +476,7 @@ function viterollEntryPlugin(
 						"if (module.parents.indexOf(parent) === -1) {",
 						"if (parent && module.parents.indexOf(parent) === -1) {",
 					)
+					.replace("if (item.deps.includes(updateModuleId)) {", "if (true) {")
 					.replace(
 						"for (var i = 0; i < module.parents.length; i++) {",
 						`

--- a/viteroll/viteroll.ts
+++ b/viteroll/viteroll.ts
@@ -252,7 +252,7 @@ export class RolldownEnvironment extends DevEnvironment {
 		const format: rolldown.ModuleFormat =
 			this.name === "client" ||
 			(this.name === "ssr" && this.viterollOptions.ssrModuleRunner)
-				? "app"
+				? "experimental-app"
 				: "esm";
 		this.outputOptions = {
 			dir: this.outDir,
@@ -322,7 +322,7 @@ ${innerCode}
 			return;
 		}
 		if (this.name === "ssr") {
-			if (this.outputOptions.format === "app") {
+			if (this.outputOptions.format === "experimental-app") {
 				const result = await this.buildHmr(ctx.file);
 				this.getRunner().evaluate(result[1].toString(), result[0]);
 			} else {


### PR DESCRIPTION
- [x] can we start with probing new module code from `chunk.modules[file].code` of build output?
  - though we don't get source map
  - ~also cannot get new modules included after edit~ (we can diff entire `chunk.modules`)
- [x] fix new module import crash
- [ ] can do something similar in rust bundler later?

This can also eliminate a hack `rolldown:hmr-deadend`.
