### PR TITLE
refactor(rsc): hypothetical core plugin

### DIFF
--- a/react-server-dom-vite-example/package.json
+++ b/react-server-dom-vite-example/package.json
@@ -12,6 +12,7 @@
 		"lint-check": "biome check ."
 	},
 	"dependencies": {
+		"@vitejs/plugin-rsc": "link:./src/core",
 		"react-server-dom-vite": "npm:@jacob-ebey/react-server-dom-vite@19.0.0-experimental.14",
 		"react": "^19.0.0",
 		"react-dom": "^19.0.0"

--- a/react-server-dom-vite-example/pnpm-lock.yaml
+++ b/react-server-dom-vite-example/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@vitejs/plugin-rsc':
+        specifier: link:./src/core
+        version: link:src/core
       react:
         specifier: ^19.0.0
         version: 19.0.0

--- a/react-server-dom-vite-example/src/core/README.md
+++ b/react-server-dom-vite-example/src/core/README.md
@@ -1,0 +1,6 @@
+This is one idea of `@vitejs/plugin-rsc` (maybe as `@vitejs/plugin-rsc/core`).
+
+The reason why this plugin + runtime code shouldn't live in `react-server-dom-vite` package is that
+the semantics of `import(...)` and virtual modules only works when they are transformed by Vite,
+however package (especially cjs) should be ideally used as external on Vite SSR without going through
+Vite transform pipepline.

--- a/react-server-dom-vite-example/src/core/client.ts
+++ b/react-server-dom-vite-example/src/core/client.ts
@@ -10,9 +10,8 @@ export const clientReferenceManifest: ClientReferenceManifest = {
 				if (import.meta.env.DEV) {
 					mod = await import(/* @vite-ignore */ id);
 				} else {
-					const references = await import(
-						"virtual:build-client-references" as string
-					);
+					// @ts-ignore
+					const references = await import("virtual:vite-rsc/client-references");
 					mod = await references.default[id]();
 				}
 				resolved = mod[name];

--- a/react-server-dom-vite-example/src/core/client.ts
+++ b/react-server-dom-vite-example/src/core/client.ts
@@ -8,6 +8,10 @@ export const clientReferenceManifest: ClientReferenceManifest = {
 			async preload() {
 				let mod: Record<string, unknown>;
 				if (import.meta.env.DEV) {
+					// TODO: this one can still break module identity due to `?import`
+					// TODO: also in practice, this `id` needs same normalization as vite's import analaysis.
+					// TODO: after doing all that, there are still issues related to external dependency and optimize deps.
+					// should such "feature" land on Vite level or worked around as Core plugin?
 					mod = await import(/* @vite-ignore */ id);
 				} else {
 					// @ts-ignore

--- a/react-server-dom-vite-example/src/core/package.json
+++ b/react-server-dom-vite-example/src/core/package.json
@@ -1,0 +1,10 @@
+{
+	"name": "@vitejs/plugin-rsc",
+	"private": true,
+	"type": "module",
+	"exports": {
+		"./plugin": "./plugin.js",
+		"./server": "./server.ts",
+		"./client": "./client.ts"
+	}
+}

--- a/react-server-dom-vite-example/src/core/plugin.js
+++ b/react-server-dom-vite-example/src/core/plugin.js
@@ -1,12 +1,19 @@
-import type { Plugin } from "vite";
-
-export function vitePluginRscCore(rscOptions: {
-	getClientReferences: () => Record<string, string>;
-	getServerReferences: () => Record<string, string>;
-}): Plugin[] {
+/**
+ *
+ * @param {{ getClientReferences: () => Record<string, string>; getServerReferences: () => Record<string, string>; }} rscOptions
+ * @returns {import("vite").Plugin}
+ */
+export function vitePluginRscCore(rscOptions) {
 	return [
 		{
-			name: "rsc-manifest",
+			name: "rsc-core",
+			configEnvironment() {
+				return {
+					resolve: {
+						noExternal: ["@vitejs/plugin-rsc"],
+					},
+				};
+			},
 			resolveId(source) {
 				if (source.startsWith("virtual:vite-rsc/")) {
 					return "\0" + source;

--- a/react-server-dom-vite-example/src/core/plugin.ts
+++ b/react-server-dom-vite-example/src/core/plugin.ts
@@ -20,7 +20,7 @@ export function vitePluginRscCore(rscOptions: {
 							? rscOptions.getServerReferences()
 							: undefined;
 				if (references) {
-					const code = Object.keys(rscOptions.getClientReferences())
+					const code = Object.keys(references)
 						.map(
 							(id) =>
 								`${JSON.stringify(id)}: () => import(${JSON.stringify(id)}),`,

--- a/react-server-dom-vite-example/src/core/plugin.ts
+++ b/react-server-dom-vite-example/src/core/plugin.ts
@@ -1,0 +1,34 @@
+import type { Plugin } from "vite";
+
+export function vitePluginRscCore(rscOptions: {
+	getClientReferences: () => Record<string, string>;
+	getServerReferences: () => Record<string, string>;
+}): Plugin[] {
+	return [
+		{
+			name: "rsc-manifest",
+			resolveId(source) {
+				if (source.startsWith("virtual:vite-rsc/")) {
+					return "\0" + source;
+				}
+			},
+			load(id) {
+				const references =
+					id === "\0virtual:vite-rsc/client-references"
+						? rscOptions.getClientReferences()
+						: id === "\0virtual:vite-rsc/server-references"
+							? rscOptions.getServerReferences()
+							: undefined;
+				if (references) {
+					const code = Object.keys(rscOptions.getClientReferences())
+						.map(
+							(id) =>
+								`${JSON.stringify(id)}: () => import(${JSON.stringify(id)}),`,
+						)
+						.join("\n");
+					return { code: `export default {${code}}`, map: { mappings: "" } };
+				}
+			},
+		},
+	];
+}

--- a/react-server-dom-vite-example/src/core/server.ts
+++ b/react-server-dom-vite-example/src/core/server.ts
@@ -1,0 +1,34 @@
+import type {
+	ClientReferenceMetadataManifest,
+	ServerReferenceManifest,
+} from "../types";
+
+export const serverReferenceManifest: ServerReferenceManifest = {
+	resolveServerReference(reference: string) {
+		const [id, name] = reference.split("#");
+		let resolved: unknown;
+		return {
+			async preload() {
+				let mod: Record<string, unknown>;
+				if (import.meta.env.DEV) {
+					mod = await import(/* @vite-ignore */ id);
+				} else {
+					// @ts-ignore
+					const references = await import("virtual:vite-rsc/server-references");
+					mod = await references.default[id]();
+				}
+				resolved = mod[name];
+			},
+			get() {
+				return resolved;
+			},
+		};
+	},
+};
+
+export const clientReferenceMetadataManifest: ClientReferenceMetadataManifest =
+	{
+		resolveClientReferenceMetadata(metadata) {
+			return metadata.$$id;
+		},
+	};

--- a/react-server-dom-vite-example/src/entry.client.tsx
+++ b/react-server-dom-vite-example/src/entry.client.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import ReactDomClient from "react-dom/client";
 import ReactClient from "react-server-dom-vite/client";
+import { clientReferenceManifest } from "./core/client";
 import type { ServerPayload } from "./entry.rsc";
 import type { CallServerFn } from "./types";
-import { clientReferenceManifest } from "./utils/client-reference";
 import { getFlightStreamBrowser } from "./utils/stream-script";
 
 async function main() {

--- a/react-server-dom-vite-example/src/entry.client.tsx
+++ b/react-server-dom-vite-example/src/entry.client.tsx
@@ -1,7 +1,7 @@
+import { clientReferenceManifest } from "@vitejs/plugin-rsc/client";
 import React from "react";
 import ReactDomClient from "react-dom/client";
 import ReactClient from "react-server-dom-vite/client";
-import { clientReferenceManifest } from "./core/client";
 import type { ServerPayload } from "./entry.rsc";
 import type { CallServerFn } from "./types";
 import { getFlightStreamBrowser } from "./utils/stream-script";

--- a/react-server-dom-vite-example/src/entry.rsc.tsx
+++ b/react-server-dom-vite-example/src/entry.rsc.tsx
@@ -1,10 +1,10 @@
-import type { ReactFormState } from "react-dom/client";
-import ReactServer from "react-server-dom-vite/server";
-import { Router } from "./app/routes";
 import {
 	clientReferenceMetadataManifest,
 	serverReferenceManifest,
-} from "./core/server";
+} from "@vitejs/plugin-rsc/server";
+import type { ReactFormState } from "react-dom/client";
+import ReactServer from "react-server-dom-vite/server";
+import { Router } from "./app/routes";
 import { fromPipeableToWebReadable } from "./utils/fetch";
 
 export interface RscHandlerResult {

--- a/react-server-dom-vite-example/src/entry.rsc.tsx
+++ b/react-server-dom-vite-example/src/entry.rsc.tsx
@@ -1,10 +1,10 @@
 import type { ReactFormState } from "react-dom/client";
 import ReactServer from "react-server-dom-vite/server";
 import { Router } from "./app/routes";
-import type {
-	ClientReferenceMetadataManifest,
-	ServerReferenceManifest,
-} from "./types";
+import {
+	clientReferenceMetadataManifest,
+	serverReferenceManifest,
+} from "./core/server";
 import { fromPipeableToWebReadable } from "./utils/fetch";
 
 export interface RscHandlerResult {
@@ -70,32 +70,3 @@ export async function handler(
 		stream,
 	};
 }
-
-const serverReferenceManifest: ServerReferenceManifest = {
-	resolveServerReference(reference: string) {
-		const [id, name] = reference.split("#");
-		let resolved: unknown;
-		return {
-			async preload() {
-				let mod: Record<string, unknown>;
-				if (import.meta.env.DEV) {
-					mod = await import(/* @vite-ignore */ id);
-				} else {
-					const references = await import("virtual:build-server-references");
-					mod = await references.default[id]();
-				}
-				resolved = mod[name];
-			},
-			get() {
-				return resolved;
-			},
-		};
-	},
-};
-
-const clientReferenceMetadataManifest: ClientReferenceMetadataManifest = {
-	resolveClientReferenceMetadata(metadata) {
-		// console.log("[debug:resolveClientReferenceMetadata]", { metadata }, Object.getOwnPropertyDescriptors(metadata));
-		return metadata.$$id;
-	},
-};

--- a/react-server-dom-vite-example/src/entry.ssr.tsx
+++ b/react-server-dom-vite-example/src/entry.ssr.tsx
@@ -1,8 +1,8 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import { clientReferenceManifest } from "@vitejs/plugin-rsc/client";
 import ReactDomServer from "react-dom/server";
 import ReactClient from "react-server-dom-vite/client";
 import type { ModuleRunner } from "vite/module-runner";
-import { clientReferenceManifest } from "./core/client";
 import type { ServerPayload } from "./entry.rsc";
 import {
 	createRequest,

--- a/react-server-dom-vite-example/src/entry.ssr.tsx
+++ b/react-server-dom-vite-example/src/entry.ssr.tsx
@@ -2,8 +2,8 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import ReactDomServer from "react-dom/server";
 import ReactClient from "react-server-dom-vite/client";
 import type { ModuleRunner } from "vite/module-runner";
+import { clientReferenceManifest } from "./core/client";
 import type { ServerPayload } from "./entry.rsc";
-import { clientReferenceManifest } from "./utils/client-reference";
 import {
 	createRequest,
 	fromPipeableToWebReadable,

--- a/react-server-dom-vite-example/vite.config.ts
+++ b/react-server-dom-vite-example/vite.config.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert";
 import path from "node:path";
 import react from "@vitejs/plugin-react";
+import { vitePluginRscCore } from "@vitejs/plugin-rsc/plugin";
 import {
 	type Manifest,
 	type Plugin,
@@ -8,7 +9,6 @@ import {
 	createRunnableDevEnvironment,
 	defineConfig,
 } from "vite";
-import { vitePluginRscCore } from "./src/core/plugin";
 
 // state for build orchestration
 let browserManifest: Manifest;

--- a/react-server-dom-vite-example/vite.config.ts
+++ b/react-server-dom-vite-example/vite.config.ts
@@ -8,6 +8,7 @@ import {
 	createRunnableDevEnvironment,
 	defineConfig,
 } from "vite";
+import { vitePluginRscCore } from "./src/core/plugin";
 
 // state for build orchestration
 let browserManifest: Manifest;
@@ -167,6 +168,10 @@ export default defineConfig({
 		vitePluginUseServer(),
 		vitePluginSilenceDirectiveBuildWarning(),
 		react(),
+		vitePluginRscCore({
+			getClientReferences: () => clientReferences,
+			getServerReferences: () => serverReferences,
+		}),
 	],
 	builder: {
 		sharedPlugins: true,
@@ -209,14 +214,6 @@ function vitePluginUseClient(): Plugin[] {
 				}
 			},
 		},
-		createVirtualPlugin("build-client-references", () => {
-			const code = Object.keys(clientReferences)
-				.map(
-					(id) => `${JSON.stringify(id)}: () => import(${JSON.stringify(id)}),`,
-				)
-				.join("\n");
-			return `export default {${code}}`;
-		}),
 	];
 }
 
@@ -252,14 +249,6 @@ function vitePluginUseServer(): Plugin[] {
 				}
 			},
 		},
-		createVirtualPlugin("build-server-references", () => {
-			const code = Object.keys(serverReferences)
-				.map(
-					(id) => `${JSON.stringify(id)}: () => import(${JSON.stringify(id)}),`,
-				)
-				.join("\n");
-			return `export default {${code}}`;
-		}),
 	];
 }
 


### PR DESCRIPTION
Part of https://github.com/users/hi-ogawa/projects/4/views/1?pane=issue&itemId=103220969

This PR moves minimal manifest handling touch point to hypothetical `@vitejs/plugin-rsc`.

The reason why this minimal plugin + runtime code shouldn't live in `react-server-dom-vite` package is that
the semantics of `import(...)` and virtual modules only works when they are transformed by Vite,
however package (especially cjs) should be ideally used as external on Vite SSR without going through
Vite transform pipepline.

Alternative would be to passing manifest through a bundler global during runtime like `__vite_rsc_server_reference_manifest__`, but then I'm not sure what's the point of that since that doesn't change from the current state where people patch `__webpack_require__` to make it work on Vite.
