### PR TITLE
fix(webpack-rsc): support `prepareDestinationWithChunks`

### DIFF
--- a/webpack-rsc/src/entry-ssr-init.ts
+++ b/webpack-rsc/src/entry-ssr-init.ts
@@ -1,3 +1,4 @@
-// for react edge build
+// for react edge build's request context support e.g.
+// https://github.com/facebook/react/blob/f14d7f0d2597ea25da12bcf97772e8803f2a394c/packages/react-server/src/forks/ReactFlightServerConfig.dom-edge.js#L16-L19
 import { AsyncLocalStorage } from "node:async_hooks";
 Object.assign(globalThis, { AsyncLocalStorage });

--- a/webpack-rsc/src/entry-ssr-init.ts
+++ b/webpack-rsc/src/entry-ssr-init.ts
@@ -1,0 +1,3 @@
+// for react edge build
+import { AsyncLocalStorage } from "node:async_hooks";
+Object.assign(globalThis, { AsyncLocalStorage });

--- a/webpack-rsc/src/entry-ssr.tsx
+++ b/webpack-rsc/src/entry-ssr.tsx
@@ -1,3 +1,4 @@
+import "./entry-ssr-init";
 import React from "react";
 import ReactDOMServer from "react-dom/server.edge";
 import ReactClient from "react-server-dom-webpack/client.edge";

--- a/webpack-rsc/src/entry-ssr.tsx
+++ b/webpack-rsc/src/entry-ssr.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import ReactDOMServer from "react-dom/server.edge";
 import ReactClient from "react-server-dom-webpack/client.edge";
 import type { FlightData } from "./entry-server";
@@ -23,13 +24,6 @@ export async function handler(request: Request) {
 
 	const [flightStream1, flightStream2] = flightStream.tee();
 
-	// react client (flight -> react node)
-	const { ssrManifest } = await getClientManifest();
-	const flightData = await ReactClient.createFromReadableStream<FlightData>(
-		flightStream1,
-		{ ssrManifest },
-	);
-
 	const assets = await getClientAssets();
 	const links = (
 		<>
@@ -46,18 +40,31 @@ export async function handler(request: Request) {
 		</>
 	);
 
-	const ssrRoot = (
-		<>
-			{flightData.node}
-			{links}
-		</>
-	);
+	// react client (flight -> react node)
+	const { ssrManifest } = await getClientManifest();
+
+	let flightData: Promise<FlightData>;
+
+	function SsrRoot() {
+		// flight deserialization needs to be kicked in inside SSR context
+		// for react-dom preinit/preloading to work
+		flightData ??= ReactClient.createFromReadableStream<FlightData>(
+			flightStream1,
+			{ ssrManifest },
+		);
+		return (
+			<>
+				{React.use(flightData).node}
+				{links}
+			</>
+		);
+	}
 
 	// react dom ssr (react node -> html)
 	let status = 200;
 	let htmlStream: ReadableStream<Uint8Array>;
 	try {
-		htmlStream = await ReactDOMServer.renderToReadableStream(ssrRoot, {
+		htmlStream = await ReactDOMServer.renderToReadableStream(<SsrRoot />, {
 			bootstrapScripts: assets.bootstrapScripts,
 			formState: actionResult,
 		});

--- a/webpack-rsc/src/lib/client-manifest.ts
+++ b/webpack-rsc/src/lib/client-manifest.ts
@@ -70,7 +70,7 @@ export async function getClientManifest() {
 	);
 	const ssrManifest: SsrManifest = {
 		moduleMap: ssrModuleMap,
-		moduleLoading: null,
+		moduleLoading: { prefix: "" },
 	};
 
 	return { browserManifest, ssrManifest };

--- a/webpack-rsc/src/lib/client-manifest.ts
+++ b/webpack-rsc/src/lib/client-manifest.ts
@@ -70,7 +70,7 @@ export async function getClientManifest() {
 	);
 	const ssrManifest: SsrManifest = {
 		moduleMap: ssrModuleMap,
-		moduleLoading: { prefix: "" },
+		moduleLoading: { prefix: "/assets/" },
 	};
 
 	return { browserManifest, ssrManifest };

--- a/webpack-rsc/src/types/react-types.ts
+++ b/webpack-rsc/src/types/react-types.ts
@@ -18,8 +18,9 @@ export type ModuleMap = {
 
 export interface SsrManifest {
 	moduleMap: ModuleMap;
-	// TODO
-	moduleLoading: null;
+	moduleLoading: {
+		prefix: string;
+	};
 }
 
 export type CallServerCallback = (id: string, args: unknown[]) => unknown;

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -6,10 +6,6 @@ import { webToNodeHandler } from "@hiogawa/utils-node";
 import webpack from "webpack";
 import { BuildManager } from "./src/lib/build-manager.js";
 
-// TODO: ensure initialized in server entry
-import { AsyncLocalStorage } from "node:async_hooks";
-Object.assign(globalThis, { AsyncLocalStorage });
-
 // SSR setup is based on
 // https://github.com/hi-ogawa/reproductions/tree/main/webpack-react-ssr
 

--- a/webpack-rsc/webpack.config.js
+++ b/webpack-rsc/webpack.config.js
@@ -6,6 +6,10 @@ import { webToNodeHandler } from "@hiogawa/utils-node";
 import webpack from "webpack";
 import { BuildManager } from "./src/lib/build-manager.js";
 
+// TODO: ensure initialized in server entry
+import { AsyncLocalStorage } from "node:async_hooks";
+Object.assign(globalThis, { AsyncLocalStorage });
+
 // SSR setup is based on
 // https://github.com/hi-ogawa/reproductions/tree/main/webpack-react-ssr
 


### PR DESCRIPTION
Finally started to understand `prepareDestinationWithChunks` after fiddling with it in https://github.com/hi-ogawa/vite-plugins/pull/703. Let's verify doing this on official webpack (though it's quite old version).
